### PR TITLE
Feature/configuration as files

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -183,7 +183,7 @@ export default async function create(argv: yargs.Arguments<any>) {
       ],
       default: 'packageJson',
     },
-    type: {
+    'type': {
       type: 'list',
       message: 'What type of package do you want to develop?',
       // @ts-ignore - seems types are wrong for inquirer

--- a/src/create.ts
+++ b/src/create.ts
@@ -20,6 +20,10 @@ const CPP_FILES = path.resolve(__dirname, '../templates/cpp-library');
 const OBJC_FILES = path.resolve(__dirname, '../templates/objc-library');
 const SWIFT_FILES = path.resolve(__dirname, '../templates/swift-library');
 const EXAMPLE_FILES = path.resolve(__dirname, '../templates/example');
+const CONFIGURATION_FILES = path.resolve(
+  __dirname,
+  '../templates/configurations'
+);
 
 type ArgName =
   | 'slug'

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs, { unlink, writeFile } from 'fs-extra';
+import fs, { writeFile } from 'fs-extra';
 import ejs from 'ejs';
 import dedent from 'dedent';
 import chalk from 'chalk';

--- a/templates/common/$package.json
+++ b/templates/common/$package.json
@@ -66,70 +66,10 @@
     "react": "*",
     "react-native": "*"
   },
-  "jest": {
-    "preset": "react-native",
-    "modulePathIgnorePatterns": [
-      "<rootDir>/example/node_modules",
-      "<rootDir>/lib/"
-    ]
-  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "yarn lint && yarn typescript"
     }
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
-  "release-it": {
-    "git": {
-      "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}"
-    },
-    "npm": {
-      "publish": true
-    },
-    "github": {
-      "release": true
-    },
-    "plugins": {
-      "@release-it/conventional-changelog": {
-        "preset": "angular"
-      }
-    }
-  },
-  "eslintConfig": {
-    "extends": [
-      "@react-native-community",
-      "prettier"
-    ],
-    "rules": {
-      "prettier/prettier": [
-        "error",
-        {
-          "quoteProps": "consistent",
-          "singleQuote": true,
-          "tabWidth": 2,
-          "trailingComma": "es5",
-          "useTabs": false
-        }
-      ]
-    }
-  },
-  "eslintIgnore": ["node_modules/", "lib/"],
-  "prettier": {
-    "quoteProps": "consistent",
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "es5",
-    "useTabs": false
-  },
-  "@react-native-community/bob": {
-    "source": "src",
-    "output": "lib",
-    "targets": ["commonjs", "module", "typescript"]
   }
 }

--- a/templates/configurations/.commitlintrc.js
+++ b/templates/configurations/.commitlintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/templates/configurations/.eslintrc.js
+++ b/templates/configurations/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: ['@react-native-community', 'prettier'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        quoteProps: 'consistent',
+        singleQuote: true,
+        tabWidth: 2,
+        trailingComma: 'es5',
+        useTabs: false,
+      },
+    ],
+  },
+  ignorePatterns: ['node_modules/', 'lib/'],
+};

--- a/templates/configurations/.release-it.js
+++ b/templates/configurations/.release-it.js
@@ -1,0 +1,17 @@
+module.exports = {
+  git: {
+    commitMessage: 'chore: release ${version}',
+    tagName: 'v${version}',
+  },
+  npm: {
+    publish: true,
+  },
+  github: {
+    release: true,
+  },
+  plugins: {
+    '@release-it/conventional-changelog': {
+      preset: 'angular',
+    },
+  },
+};

--- a/templates/configurations/bob.config.js
+++ b/templates/configurations/bob.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  source: 'src',
+  output: 'lib',
+  targets: ['commonjs', 'module', 'typescript'],
+};

--- a/templates/configurations/jest.config.js
+++ b/templates/configurations/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'react-native',
+  modulePathIgnorePatterns: [
+    '<rootDir>/example/node_modules',
+    '<rootDir>/lib/',
+  ],
+};

--- a/templates/configurations/prettier.config.js
+++ b/templates/configurations/prettier.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  quoteProps: 'consistent',
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'es5',
+  useTabs: false,
+};


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
This PRs adds the option to store the configurations of prettier, eslint, ... as seperate files instead of pacakge.json.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
