### PR TITLE
Update example's Podfile minimum deployment target

### DIFF
--- a/templates/example/example/ios/Podfile
+++ b/templates/example/example/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 def add_flipper_pods!


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This fixes execution of `yarn bootstrap`

```
[!] CocoaPods could not find compatible versions for pod "react-native-awesome-module":
  In Podfile:
    react-native-awesome-module (from `../..`)

Specs satisfying the `react-native-awesome-module (from `../..`)` dependency were found, but they required a higher minimum deployment target.
```

### Test plan

```
$ npm install -g https://github.com/callstack/react-native-builder-bob#85835e6
$ /usr/local/Cellar/node/14.11.0/lib/node_modules/@react-native-community/bob/bin/bob.js create react-native-awesome-module
$ cd react-native-awesome-module
$ yarn bootstrap
```

With this fix, you won't get the Cocoapod error I reported in the summary.