### PR TITLE
fix: add support for 'jsx' file extention

### DIFF
--- a/src/utils/compile.ts
+++ b/src/utils/compile.ts
@@ -40,11 +40,11 @@ export default async function compile({
     files.map(async (filepath) => {
       const outputFilename = path
         .join(output, path.relative(source, filepath))
-        .replace(/\.(js|tsx?)$/, '.js');
+        .replace(/\.(jsx?|tsx?)$/, '.js');
 
       await fs.mkdirp(path.dirname(outputFilename));
 
-      if (!/\.(js|tsx?)$/.test(filepath)) {
+      if (!/\.(jsx?|tsx?)$/.test(filepath)) {
         // Copy files which aren't source code
         fs.copy(filepath, outputFilename);
         return;

--- a/templates/expo-library/example/webpack.config.js
+++ b/templates/expo-library/example/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
 
   config.module.rules.push({
-    test: /\.(js|ts|tsx)$/,
+    test: /\.(js|jsx|ts|tsx)$/,
     include: path.resolve(root, 'src'),
     use: 'babel-loader',
   });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Hello I have multiple project and we use `.jsx` extension in their source code.

### Test plan

- Simply create a file with extension `.js`
- Copy the file with a other name and the extension `.jsx`
- Compare the output file to see that they are the same