### PR TITLE
chore: override yarn command to make repo setup easier

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -317,7 +317,7 @@ export default async function create(argv: yargs.Arguments<any>) {
 
       {magenta {bold Get started} with the project}{gray :}
 
-        {gray $} yarn bootstrap
+        {gray $} yarn
       ${Object.entries(platforms)
         .map(
           ([script, { name, color }]) => chalk`

--- a/templates/common/$.yarnrc
+++ b/templates/common/$.yarnrc
@@ -1,0 +1,3 @@
+# Override Yarn command so we can automatically setup the repo on running `yarn`
+
+yarn-path "scripts/bootstrap.js"

--- a/templates/common/CONTRIBUTING.md
+++ b/templates/common/CONTRIBUTING.md
@@ -4,10 +4,10 @@ We want this community to be friendly and respectful to each other. Please follo
 
 ## Development workflow
 
-To get started with the project, run `yarn bootstrap` in the root directory to install the required dependencies for each package:
+To get started with the project, run `yarn` in the root directory to install the required dependencies for each package:
 
 ```sh
-yarn bootstrap
+yarn
 ```
 
 While developing, you can run the [example app](/example/) to test your changes.

--- a/templates/common/scripts/bootstrap.js
+++ b/templates/common/scripts/bootstrap.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const child_process = require('child_process');
+
+const root = path.resolve(__dirname, '..');
+const args = process.argv.slice(2);
+const options = {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: 'inherit',
+  encoding: 'utf-8',
+};
+
+let result;
+
+if (process.cwd() !== root || args.length) {
+  // We're not in the root of the project, or additional arguments were passed
+  // In this case, forward the command to `yarn`
+  result = child_process.spawnSync('yarn', args, options);
+} else {
+  // If `yarn` is run without arguments, perform bootstrap
+  result = child_process.spawnSync('yarn', ['bootstrap'], options);
+}
+
+process.exitCode = result.status;


### PR DESCRIPTION
Currently we need to run 'yarn bootstrap' to setup the repo. However it's easy to forget. This PR overrides the Yarn command to run the 'bootstrap' script if no arguments are specified.
