### PR TITLE
fix: add publishConfig to make release-it work

### DIFF
--- a/templates/common/$package.json
+++ b/templates/common/$package.json
@@ -41,6 +41,9 @@
     "url": "<%= repo %>/issues"
   },
   "homepage": "<%= repo %>#readme",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^8.3.4",
     "@react-native-community/bob": "^<%= bob.version %>",


### PR DESCRIPTION
Sometimes release-it fails if publishConfig isn't specified. So this adds it to the default template.