### PR TITLE
Fix EJS formatting issues

### DIFF
--- a/templates/common/example/src/App.tsx
+++ b/templates/common/example/src/App.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-<% if (project.moduleType === "view") { %>
+
+<% if (project.moduleType === "view") { -%>
 import { StyleSheet, View } from 'react-native';
 import <%- project.name %>ViewManager from '<%- project.slug %>';
-<% } else { %>
+<% } else { -%>
 import { StyleSheet, View, Text } from 'react-native';
 import <%- project.name %> from '<%- project.slug %>';
-<% } %>
-<% if (project.moduleType === "view") { %>
+<% } -%>
+
+<% if (project.moduleType === "view") { -%>
 export default function App() {
   return (
     <View style={styles.container}>
@@ -14,7 +16,7 @@ export default function App() {
     </View>
   );
 }
-<% } else { %>
+<% } else { -%>
 export default function App() {
   const [result, setResult] = React.useState<number | undefined>();
 
@@ -28,7 +30,8 @@ export default function App() {
     </View>
   );
 }
-<% } %>
+<% } -%>
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/templates/example/example/ios/Podfile
+++ b/templates/example/example/ios/Podfile
@@ -7,10 +7,10 @@ target '<%- project.name %>Example' do
   config = use_native_modules!
 
   use_react_native!(:path => config["reactNativePath"])
+<% if (project.module) { -%>
 
-  <% if (project.module) { -%>
-    pod '<%- project.podspec %>', :path => '../..'
-  <% } -%>
+  pod '<%- project.podspec %>', :path => '../..'
+<% } -%>
 
   # Enables Flipper.
   #

--- a/templates/native-library/{%- project.podspec %}.podspec
+++ b/templates/native-library/{%- project.podspec %}.podspec
@@ -13,13 +13,13 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "10.0" }
   s.source       = { :git => "<%- repo %>.git", :tag => "#{s.version}" }
 
-  <% if (project.cpp) { %>
+<% if (project.cpp) { -%>
   s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp}"
-  <% } else if (project.swift) { %>
+<% } else if (project.swift) { -%>
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  <% } else { %>
+<% } else { -%>
   s.source_files = "ios/**/*.{h,m,mm}"
-  <% } %>
+<% } -%>
 
   s.dependency "React-Core"
 end

--- a/templates/native-view-library/src/index.tsx
+++ b/templates/native-view-library/src/index.tsx
@@ -5,7 +5,6 @@ type <%- project.name %>Props = {
   style: ViewStyle;
 };
 
-
 export const <%- project.name %>ViewManager = requireNativeComponent<<%- project.name %>Props>(
   '<%- project.name %>View'
 );

--- a/templates/native-view-library/{%- project.podspec %}.podspec
+++ b/templates/native-view-library/{%- project.podspec %}.podspec
@@ -13,13 +13,13 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "10.0" }
   s.source       = { :git => "<%- repo %>.git", :tag => "#{s.version}" }
 
-  <% if (project.cpp) { %>
+<% if (project.cpp) { -%>
   s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp}"
-  <% } else if (project.swift) { %>
+<% } else if (project.swift) { -%>
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  <% } else { %>
+<% } else { -%>
   s.source_files = "ios/**/*.{h,m,mm}"
-  <% } %>
+<% } -%>
 
   s.dependency "React-Core"
 end


### PR DESCRIPTION
### Summary

A couple of related fixes to the EJS statements:

#### Remove leading spaces

Full length EJS lines should _not_ be indented as if they were semantically on same level as the code they encapsulate. Instead, they should be considered independent statements that _assemble indented code_. Otherwise the processed files will contain whitespace errors (i.e. spaces followed by EOL).

#### Slurp newlines

Change the end marker `%>` to `-%>` for full line ejs statements. What this does is it will _omit_ the newline character in the processed file. Depending on the conditional path, `yarn lint` (ESLint) was failing with a double blank line, e.g.:

```
[...]/example/src/App.tsx
  6:1  error  Delete `⏎`  prettier/prettier
```

### Test plan

Create new project and check generated files are whitespace error free. Verify `yarn lint` passes.