### PR TITLE
fix hmr errors

### DIFF
--- a/templates/example/example/babel.config.js
+++ b/templates/example/example/babel.config.js
@@ -7,6 +7,7 @@ module.exports = {
     [
       'module-resolver',
       {
+        extensions: ['.js', '.ts', '.json', '.jsx', '.tsx'],
         alias: {
           [pak.name]: path.join(__dirname, '..', pak.source),
         },

--- a/templates/expo-library/example/babel.config.js
+++ b/templates/expo-library/example/babel.config.js
@@ -10,6 +10,7 @@ module.exports = function (api) {
       [
         'module-resolver',
         {
+          extensions: ['.js', '.ts', '.json', '.jsx', '.tsx'],
           alias: {
             // For development, we want to alias the library to the source
             [pak.name]: path.join(__dirname, '..', pak.source),


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Fixes HMR errors that present as `transform[stderr]: Could not resolve blah blah blah`

Closes #127

### Test plan

Add `extensions: ['.js', '.ts', '.json', '.jsx', '.tsx'],` to an existing project's module-resolver and HMR errors will go away
