### PR TITLE
fix: wrong types path

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To configure your project manually, follow these steps:
    "main": "lib/commonjs/index.js",
    "module": "lib/module/index.js",
    "react-native": "src/index.ts",
-   "types": "lib/typescript/src/index.d.ts",
+   "types": "lib/typescript/index.d.ts",
    "files": [
      "lib/",
      "src/"

--- a/templates/common/$package.json
+++ b/templates/common/$package.json
@@ -4,7 +4,7 @@
   "description": "<%- project.description %>",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
### Summary

The generated declaration file ends up in lib/typescript/index.d.ts but package.json points to lib/typescript/src/index.d.ts

### Test plan

1. npx react-native-builder-bob create react-native-awesome-module
2. What type of package do you want to develop? › Native module in Kotlin and Objective-C
3. run: yarn
4. Find the generated declaration file in lib/typescript/index.d.ts (not in a src folder)

