### PR TITLE
fix: fallback bob version

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -343,7 +343,6 @@ async function create(argv: yargs.Arguments<any>) {
     ]);
   } catch (e) {
     // Fallback to a known version if we couldn't fetch
-    version = FALLBACK_BOB_VERSION;
   }
 
   const options = {

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -21,6 +21,8 @@ const NATIVE_COMMON_FILES = path.resolve(
   '../templates/native-common'
 );
 
+const FALLBACK_BOB_VERSION = '0.18.0';
+
 // Java
 const JAVA_FILES = (moduleType: ModuleType) => {
   switch (moduleType) {
@@ -319,7 +321,7 @@ async function create(argv: yargs.Arguments<any>) {
       : 'module';
 
   // Get latest version of Bob from NPM
-  let version: string;
+  let version: string = FALLBACK_BOB_VERSION;
 
   try {
     version = await Promise.race([
@@ -341,7 +343,7 @@ async function create(argv: yargs.Arguments<any>) {
     ]);
   } catch (e) {
     // Fallback to a known version if we couldn't fetch
-    version = '0.18.0';
+    version = FALLBACK_BOB_VERSION;
   }
 
   const options = {

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -321,12 +321,12 @@ async function create(argv: yargs.Arguments<any>) {
       : 'module';
 
   // Get latest version of Bob from NPM
-  let version: string = FALLBACK_BOB_VERSION;
+  let version: string;
 
   try {
     version = await Promise.race([
       new Promise<string>((resolve) =>
-        setTimeout(() => resolve(version), 1000)
+        setTimeout(() => resolve(FALLBACK_BOB_VERSION), 1000)
       ),
       new Promise<string>((resolve, reject) => {
         const npm = spawn('npm', [
@@ -343,11 +343,12 @@ async function create(argv: yargs.Arguments<any>) {
     ]);
   } catch (e) {
     // Fallback to a known version if we couldn't fetch
+    version = FALLBACK_BOB_VERSION;
   }
 
   const options = {
     bob: {
-      version,
+      version: version || FALLBACK_BOB_VERSION,
     },
     project: {
       slug,


### PR DESCRIPTION
### Summary

Closes https://github.com/callstack/react-native-builder-bob/issues/145

The fallback version was incorrect. This PR fixes it.

### Test plan

Like always :D 
