### PR TITLE
Fix broken egghead link

### DIFF
--- a/packages/create-react-native-library/templates/common/CONTRIBUTING.md
+++ b/packages/create-react-native-library/templates/common/CONTRIBUTING.md
@@ -106,7 +106,7 @@ The `package.json` file contains various scripts for common tasks:
 
 ### Sending a pull request
 
-> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
 
 When you're sending a pull request:
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a broken egghead link in the CONTRIBUTING.md file.

![Screenshot 2021-04-07 at 13 18 21](https://user-images.githubusercontent.com/15199031/113858181-bb229000-97a3-11eb-920b-5a6a23b4638c.png)


### Test plan

Click on the "How to Contribute to an Open Source Project on GitHub" link in CONTRIBUTING.md
