### PR TITLE
Fix wrong package name of ReactNativeFlipper

### DIFF
--- a/packages/create-react-native-library/templates/example/example/android/app/src/main/java/com/example/{%- project.package %}/MainApplication.java
+++ b/packages/create-react-native-library/templates/example/example/android/app/src/main/java/com/example/{%- project.package %}/MainApplication.java
@@ -64,7 +64,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.<%- project.package %>Example.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.example.<%- project.package %>.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
When the Flipper is enabled, the generated code package name is wrong.
It will throw a runtime error since can't find the ReactNativeFlipper class.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
