### PR TITLE
`blacklist` -> `exclusionList` migration for examples metro.config.js

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -62,7 +62,7 @@
     "pod-install": "^0.1.0",
     "prettier": "^2.0.5",
     "react": "16.13.1",
-    "react-native": "0.63.4",
+    "react-native": "0.64.0",
     "react-native-builder-bob": "^<%- bob.version %>",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"

--- a/packages/create-react-native-library/templates/common/example/metro.config.js
+++ b/packages/create-react-native-library/templates/common/example/metro.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
 const escape = require('escape-string-regexp');
 const pak = require('../package.json');
 
@@ -14,9 +14,9 @@ module.exports = {
   watchFolders: [root],
 
   // We need to make sure that only one version is loaded for peerDependencies
-  // So we blacklist them at the root, and alias them to the versions in example's node_modules
+  // So we block them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    blacklistRE: blacklist(
+    exclusionListRE: exclusionList(
       modules.map(
         (m) =>
           new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)

--- a/packages/create-react-native-library/templates/common/example/metro.config.js
+++ b/packages/create-react-native-library/templates/common/example/metro.config.js
@@ -16,7 +16,7 @@ module.exports = {
   // We need to make sure that only one version is loaded for peerDependencies
   // So we block them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    exclusionListRE: exclusionList(
+    blacklistRE: exclusionList(
       modules.map(
         (m) =>
           new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)


### PR DESCRIPTION
This pull request fixes #160 

It changes the *blacklist* to *exclusionList* in the example *metro.config.js* file so it is compatible with React Native v0.64.x.
It also updates the React Native version of example to v0.64.0

---

Two main changes are introduced in this delivery:
* Update the version of React Native to 0.64.0
This is done to ensure a compatibility with *exclusionList*.
Please note that once React Native Windows is supported it will most likely require the 0.64.x version of both RN and RNW.
* Change all occurrences of `blacklist` to `exclusionList` in *templates/common/example/metro.config.js*

