### PR TITLE
remove buildToolsVersion

### DIFF
--- a/packages/create-react-native-library/templates/example/example/android/build.gradle
+++ b/packages/create-react-native-library/templates/example/example/android/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
         minSdkVersion = 16
         compileSdkVersion = 29
         targetSdkVersion = 29

--- a/packages/create-react-native-library/templates/java-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/java-library/android/build.gradle
@@ -19,7 +19,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('<%- project.name %>_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('<%- project.name %>_buildToolsVersion', '29.0.2')
     defaultConfig {
         minSdkVersion safeExtGet('<%- project.name %>_minSdkVersion', 16)
         targetSdkVersion safeExtGet('<%- project.name %>_targetSdkVersion', 29)

--- a/packages/create-react-native-library/templates/java-view-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/java-view-library/android/build.gradle
@@ -19,7 +19,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('<%- project.name %>_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('<%- project.name %>_buildToolsVersion', '29.0.2')
     defaultConfig {
         minSdkVersion safeExtGet('<%- project.name %>_minSdkVersion', 16)
         targetSdkVersion safeExtGet('<%- project.name %>_targetSdkVersion', 29)

--- a/packages/create-react-native-library/templates/kotlin-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/kotlin-library/android/build.gradle
@@ -27,7 +27,6 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-  buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
     minSdkVersion 16
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')

--- a/packages/create-react-native-library/templates/kotlin-library/android/gradle.properties
+++ b/packages/create-react-native-library/templates/kotlin-library/android/gradle.properties
@@ -1,4 +1,3 @@
 <%- project.name %>_kotlinVersion=1.3.50
 <%- project.name %>_compileSdkVersion=29
-<%- project.name %>_buildToolsVersion=29.0.2
 <%- project.name %>_targetSdkVersion=29

--- a/packages/create-react-native-library/templates/kotlin-view-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/kotlin-view-library/android/build.gradle
@@ -27,7 +27,6 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-  buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
     minSdkVersion 16
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')

--- a/packages/create-react-native-library/templates/kotlin-view-library/android/gradle.properties
+++ b/packages/create-react-native-library/templates/kotlin-view-library/android/gradle.properties
@@ -1,4 +1,3 @@
 <%- project.name %>_kotlinVersion=1.3.50
 <%- project.name %>_compileSdkVersion=29
-<%- project.name %>_buildToolsVersion=29.0.2
 <%- project.name %>_targetSdkVersion=29


### PR DESCRIPTION
### Summary

Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
