### PR TITLE
fix: call the gradle wrapper correctly on windows

### DIFF
--- a/packages/react-native-builder-bob/src/utils/androidAssemble.ts
+++ b/packages/react-native-builder-bob/src/utils/androidAssemble.ts
@@ -24,8 +24,7 @@ export default async function androidAssemble({
     )}`
   );
 
-  const gradleWrapper =
-    './gradlew' + (platform() === 'win32' ? './gradlew.bat' : '');
+  const gradleWrapper = platform() === 'win32' ? 'gradlew.bat' : './gradlew';
   if (await fs.pathExists(path.join(androidPath, gradleWrapper))) {
     execFileSync(gradleWrapper, ['assemble'], { cwd: androidPath });
   } else {


### PR DESCRIPTION
### Summary

This addresses [this issue](https://github.com/callstack/react-native-builder-bob/issues/79) by fixing the command used to call the gradle wrapper on Windows. 

### Test plan

Following the steps outlined in the issue linked above should no longer result in an error that says the gradle wrapper doesn't appear to be present.
