### PR TITLE
update expo sdk version to 42

### DIFF
--- a/packages/create-react-native-library/templates/expo-library/example/$package.json
+++ b/packages/create-react-native-library/templates/expo-library/example/$package.json
@@ -12,16 +12,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "expo": "^40.0.0",
-    "expo-splash-screen": "~0.8.1",
+    "expo": "^42.0.0",
+    "expo-splash-screen": "~0.11.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-unimodules": "~0.12.0",
-    "react-native-web": "~0.14.9"
+    "react-native-unimodules": "~0.14.5",
+    "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "~7.12.10",
+    "@babel/core": "~7.9.0",
     "@babel/runtime": "^7.9.6",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-expo": "8.3.0",


### PR DESCRIPTION
### Summary

The current SDK version (40) is not working with `react-native-reanimated 2`
so this PR will solve it.
fixing #191 
