### PR TITLE
feat(bob): add `concurrent` and `failFast` config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ To configure your project manually, follow these steps:
    "react-native-builder-bob": {
      "source": "src",
      "output": "lib",
+     "concurrent": false,
+     "failFast": false,
      "targets": [
        ["aar", {"reverseJetify": true}],
        ["commonjs", {"copyFlow": true}],
@@ -185,6 +187,14 @@ Example:
 ```json
 ["aar", { "reverseJetify": true }]
 ```
+
+#### `concurrent`
+
+Set to `true` to run all build stages concurrently.
+
+#### `failFast`
+
+If the `concurrent` option is `true`, setting this option to `true` will exit all builds immediately if any build fails. Ignored if `concurrent` is `false`.
 
 ## FAQ
 

--- a/packages/react-native-builder-bob/src/types.ts
+++ b/packages/react-native-builder-bob/src/types.ts
@@ -16,6 +16,8 @@ export type Input = {
 export type Target = 'aar' | 'commonjs' | 'module' | 'typescript';
 
 export type Options = {
+  concurrent?: boolean;
+  failFast?: boolean;
   source?: string;
   output?: string;
   targets?: (Target | [Target, object])[];


### PR DESCRIPTION
#### `concurrent`

Set to `true` to run all build stages concurrently.

#### `failFast`

If the `concurrent` option is `true`, setting this option to `true` will exit all builds immediately if any build fails. Ignored if `concurrent` is `false`.