### PR TITLE
fix(android): prefer downloading dependencies from Maven Central

### DIFF
--- a/packages/create-react-native-library/templates/example/example/android/build.gradle
+++ b/packages/create-react-native-library/templates/example/example/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -31,6 +32,7 @@ allprojects {
         }
 
         google()
+        mavenCentral()
         jcenter()
         maven { url 'https://www.jitpack.io' }
     }

--- a/packages/create-react-native-library/templates/java-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/java-library/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            mavenCentral()
             jcenter()
         }
 
@@ -61,6 +62,7 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
+    mavenCentral()
     jcenter()
 }
 

--- a/packages/create-react-native-library/templates/java-view-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/java-view-library/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            mavenCentral()
             jcenter()
         }
 
@@ -61,6 +62,7 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
+    mavenCentral()
     jcenter()
 }
 

--- a/packages/create-react-native-library/templates/kotlin-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/kotlin-library/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
 
   repositories {
     google()
+    mavenCentral()
     jcenter()
   }
 

--- a/packages/create-react-native-library/templates/kotlin-view-library/android/build.gradle
+++ b/packages/create-react-native-library/templates/kotlin-view-library/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
 
   repositories {
     google()
+    mavenCentral()
     jcenter()
   }
 


### PR DESCRIPTION
### Summary

Recent react-native dependencies are published to Maven Central only.

### Test plan

Check if `mavenCentral` is above `jcenter` in repo structure 

More context here: https://github.com/react-native-camera/react-native-camera/issues/2490