### PR TITLE
fix: metro blacklist case sensitivity #133

### DIFF
--- a/packages/create-react-native-library/templates/common/example/metro.config.js
+++ b/packages/create-react-native-library/templates/common/example/metro.config.js
@@ -16,12 +16,12 @@ module.exports = {
   // We need to make sure that only one version is loaded for peerDependencies
   // So we blacklist them at the root, and alias them to the versions in example's node_modules
   resolver: {
-    blacklistRE: blacklist(
+    blacklistRE: new RegExp(blacklist(
       modules.map(
         (m) =>
           new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
       )
-    ),
+    ), 'i'),
 
     extraNodeModules: modules.reduce((acc, name) => {
       acc[name] = path.join(__dirname, 'node_modules', name);


### PR DESCRIPTION
This fixes the issue #133.

### Summary

When using a different command like like **cmder**, the path is for example: c:\\my-lib\\ and with the normal windows command like the path is C:\\my-lib\\ with the **C** in upper case, and with the **c** in lower case the blacklist regex in metro will not work because it's case sensitive.

### Test plan

Use a command like that uses lower case paths, for example **cmder**
