### PR TITLE
chore: add @babel/core as dev dependency

### DIFF
--- a/packages/create-react-native-library/package.json
+++ b/packages/create-react-native-library/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
+    "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
     "@commitlint/config-conventional": "^11.0.0",


### PR DESCRIPTION
### Summary

When you run  _yarn install_, it's showing warning about @babel/core dependency, and this change removes warnings.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
