### PR TITLE
fix: remove double-quoted imports from React-Core

### DIFF
--- a/packages/create-react-native-library/templates/swift-view-library/ios/{%- project.name %}ViewManager.m
+++ b/packages/create-react-native-library/templates/swift-view-library/ios/{%- project.name %}ViewManager.m
@@ -1,4 +1,4 @@
-#import "React/RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RCT_EXTERN_MODULE(<%- project.name %>ViewManager, RCTViewManager)
 


### PR DESCRIPTION
### Summary

according to https://github.com/expo/expo/issues/15622#issuecomment-997225774, we should use `#import <React/RCTViewManager.h>` instead of double-quoted import.

### Test plan

regression test by creating a test library and running the example (`yarn && yarn example ios`).