### PR TITLE
fix: fixed lint throw error without semicolon

### DIFF
--- a/packages/create-react-native-library/templates/common/scripts/bootstrap.js
+++ b/packages/create-react-native-library/templates/common/scripts/bootstrap.js
@@ -12,7 +12,7 @@ const options = {
 };
 
 if (os.type() === 'Windows_NT') {
-  options.shell = true
+  options.shell = true;
 }
 
 let result;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixed es lint throwing error without semicolon

### Test plan

I have tested with my repo. You can check here [https://github.com/kyawthura-gg/react-native-skeletons/commit/d30c7b0cb010138086a2da093db03c644c7ab946](https://github.com/kyawthura-gg/react-native-skeletons/commit/d30c7b0cb010138086a2da093db03c644c7ab946)