### PR TITLE
Fix/ts custom config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">= 10.0.0"
   },
   "scripts": {
-    "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "typescript": "tsc --noEmit",
     "watch": "concurrently 'yarn typescript --watch' 'lerna run --parallel prepare -- --watch'"
   },

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -28,6 +28,15 @@ export default async function build({
 
   const project = options?.project ? options.project : 'tsconfig.json';
   const tsconfig = path.join(root, project);
+  let tscSpawnSyncOptions = [
+    '--pretty',
+    '--declaration',
+    '--emitDeclarationOnly',
+    '--project',
+    project,
+    '--outDir',
+    output,
+  ];
 
   try {
     if (await fs.pathExists(tsconfig)) {
@@ -38,11 +47,17 @@ export default async function build({
           const conflicts: string[] = [];
 
           if (config.compilerOptions.noEmit !== undefined) {
-            conflicts.push('compilerOptions.noEmit');
+            tscSpawnSyncOptions.splice(
+              0,
+              tscSpawnSyncOptions.indexOf('--noEmit')
+            );
           }
 
           if (config.compilerOptions.emitDeclarationOnly !== undefined) {
-            conflicts.push('compilerOptions.emitDeclarationOnly');
+            tscSpawnSyncOptions.splice(
+              0,
+              tscSpawnSyncOptions.indexOf('--emitDeclarationOnly')
+            );
           }
 
           if (config.compilerOptions.declarationDir) {
@@ -127,19 +142,7 @@ export default async function build({
       // Ignore
     }
 
-    const result = spawn.sync(
-      tsc,
-      [
-        '--pretty',
-        '--declaration',
-        '--emitDeclarationOnly',
-        '--project',
-        project,
-        '--outDir',
-        output,
-      ],
-      { stdio: 'inherit' }
-    );
+    const result = spawn.sync(tsc, tscSpawnSyncOptions, { stdio: 'inherit' });
 
     if (result.status === 0) {
       await del([tsbuildinfo]);

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -47,19 +47,28 @@ export default async function build({
           const conflicts: string[] = [];
 
           if (config.compilerOptions.noEmit !== undefined) {
-            tscSpawnSyncOptions.splice( tscSpawnSyncOptions.indexOf('--noEmit'), 1);
+            tscSpawnSyncOptions.splice(
+              tscSpawnSyncOptions.indexOf('--noEmit'),
+              1
+            );
           }
 
           if (config.compilerOptions.emitDeclarationOnly !== undefined) {
-            tscSpawnSyncOptions.splice(tscSpawnSyncOptions.indexOf('--emitDeclarationOnly'), 1);
+            tscSpawnSyncOptions.splice(
+              tscSpawnSyncOptions.indexOf('--emitDeclarationOnly'),
+              1
+            );
           }
 
           if (config.compilerOptions.declarationDir) {
             conflicts.push('compilerOptions.declarationDir');
           }
 
-          if (config.compilerOptions.declaration) {
-            tscSpawnSyncOptions.splice(tscSpawnSyncOptions.indexOf('--declaration'), 1);
+          if (config.compilerOptions.declaration !== undefined) {
+            tscSpawnSyncOptions.splice(
+              tscSpawnSyncOptions.indexOf('--declaration'),
+              1
+            );
           }
 
           if (

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -47,21 +47,19 @@ export default async function build({
           const conflicts: string[] = [];
 
           if (config.compilerOptions.noEmit !== undefined) {
-            tscSpawnSyncOptions.splice(
-              0,
-              tscSpawnSyncOptions.indexOf('--noEmit')
-            );
+            tscSpawnSyncOptions.splice( tscSpawnSyncOptions.indexOf('--noEmit'), 1);
           }
 
           if (config.compilerOptions.emitDeclarationOnly !== undefined) {
-              tscSpawnSyncOptions.splice(
-                0,
-                tscSpawnSyncOptions.indexOf('--emitDeclarationOnly')
-              );
+            tscSpawnSyncOptions.splice(tscSpawnSyncOptions.indexOf('--emitDeclarationOnly'), 1);
           }
 
           if (config.compilerOptions.declarationDir) {
             conflicts.push('compilerOptions.declarationDir');
+          }
+
+          if (config.compilerOptions.declaration) {
+            tscSpawnSyncOptions.splice(tscSpawnSyncOptions.indexOf('--declaration'), 1);
           }
 
           if (

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -47,25 +47,17 @@ export default async function build({
           const conflicts: string[] = [];
 
           if (config.compilerOptions.noEmit !== undefined) {
-            if (config.compilerOptions.noEmit === true) {
-              tscSpawnSyncOptions.splice(
-                0,
-                tscSpawnSyncOptions.indexOf('--noEmit')
-              );
-            } else {
-              conflicts.push('compilerOptions.noEmit');
-            }
+            tscSpawnSyncOptions.splice(
+              0,
+              tscSpawnSyncOptions.indexOf('--noEmit')
+            );
           }
 
           if (config.compilerOptions.emitDeclarationOnly !== undefined) {
-            if (config.compilerOptions.emitDeclarationOnly === true) {
               tscSpawnSyncOptions.splice(
                 0,
                 tscSpawnSyncOptions.indexOf('--emitDeclarationOnly')
               );
-            } else {
-              conflicts.push('compilerOptions.emitDeclarationOnly');
-            }
           }
 
           if (config.compilerOptions.declarationDir) {

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -47,17 +47,25 @@ export default async function build({
           const conflicts: string[] = [];
 
           if (config.compilerOptions.noEmit !== undefined) {
-            tscSpawnSyncOptions.splice(
-              0,
-              tscSpawnSyncOptions.indexOf('--noEmit')
-            );
+            if (config.compilerOptions.noEmit === true) {
+              tscSpawnSyncOptions.splice(
+                0,
+                tscSpawnSyncOptions.indexOf('--noEmit')
+              );
+            } else {
+              conflicts.push('compilerOptions.noEmit');
+            }
           }
 
           if (config.compilerOptions.emitDeclarationOnly !== undefined) {
-            tscSpawnSyncOptions.splice(
-              0,
-              tscSpawnSyncOptions.indexOf('--emitDeclarationOnly')
-            );
+            if (config.compilerOptions.emitDeclarationOnly === true) {
+              tscSpawnSyncOptions.splice(
+                0,
+                tscSpawnSyncOptions.indexOf('--emitDeclarationOnly')
+              );
+            } else {
+              conflicts.push('compilerOptions.emitDeclarationOnly');
+            }
           }
 
           if (config.compilerOptions.declarationDir) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
When I define in the configuration file of some project the information: noEmit, the lib doesn't let me execute this because it doesn't accept a configuration from the user. This is a problem in cases where the user does not want to issue a configuration file.
It also prevents me from making settings from my tsconfig file.
This pr is intended to fix that.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Try to create a lib and in the project's tsconfig file, add the parameter noEmit: true
react-native-builder-bob doesn't allow you to do that.