### PR TITLE
fix: include header with project identifier for cpp

### DIFF
--- a/packages/create-react-native-library/templates/cpp-library/android/cpp-adapter.cpp
+++ b/packages/create-react-native-library/templates/cpp-library/android/cpp-adapter.cpp
@@ -1,5 +1,5 @@
 #include <jni.h>
-#include "example.h"
+#include "<%- project.identifier %>.h"
 
 extern "C"
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
### Summary

The `cpp` template has the wrong include header.

### Test plan

```
npx create-react-native-library react-native-simple-turbo
cd react-native-simple-turbo
yarn example android
```
