### PR TITLE
feat(ios): enable function generation by Xcode with CodeGen interface

### DIFF
--- a/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
+++ b/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
@@ -1,5 +1,13 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "RN<%- project.name -%>Spec.h"
+#else
 #import <React/RCTBridgeModule.h>
+#endif
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface <%- project.name -%> : NSObject <Native<%- project.name -%>Spec>
+#else
 @interface <%- project.name -%> : NSObject <RCTBridgeModule>
+#endif
 
 @end

--- a/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
+++ b/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
@@ -1,12 +1,10 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RN<%- project.name -%>Spec.h"
-#else
-#import <React/RCTBridgeModule.h>
-#endif
 
-#ifdef RCT_NEW_ARCH_ENABLED
 @interface <%- project.name -%> : NSObject <Native<%- project.name -%>Spec>
 #else
+#import <React/RCTBridgeModule.h>
+
 @interface <%- project.name -%> : NSObject <RCTBridgeModule>
 #endif
 

--- a/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.mm
+++ b/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.mm
@@ -1,25 +1,34 @@
 #import "<%- project.name -%>.h"
 
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RN<%- project.name -%>Spec.h"
-#endif
-
 @implementation <%- project.name -%>
 
 RCT_EXPORT_MODULE()
 
-// Example method
-// See // https://reactnative.dev/docs/native-modules-ios
 <% if (project.architecture == 'turbo') { -%>
-RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(multiply,
-                                      NSNumber *,
-                                      multiplyWithA:(double)a  withB:(double)b)
-{
+- (NSNumber *)multiply:(double)a b:(double)b {
     NSNumber *result = @(a * b);
 
     return result;
 }
+<% } else if (project.architecture == 'mixed') { -%>
+// Example method
+// See // https://reactnative.dev/docs/native-modules-ios
+RCT_REMAP_METHOD(multiply,
+                 multiplyWithA:(double)a  withB:(double)b
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self multiply:a b:b resolve:resolve reject:reject];
+}
+
+- (void)multiply:(double)a b:(double)b resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    NSNumber *result = @(a * b);
+
+    resolve(result);
+}
 <% } else { -%>
+// Example method
+// See // https://reactnative.dev/docs/native-modules-ios
 RCT_REMAP_METHOD(multiply,
                  multiplyWithA:(double)a withB:(double)b
                  withResolver:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When I use Turbo module, today If I define a new method (on JS side) in my turbo module interface Native{%- project.name %}.ts, codegen generates new files. But I do not have in Xcode any warning or error that tells me to implement this new method.

Find more details in this discussion: #261 

### Test plan

#### TurboModule only

1. Generate a new library with Turbo module <img width="421" alt="image" src="https://user-images.githubusercontent.com/9041221/186720784-280933a9-42be-424d-b182-b5edb7d95d32.png">
2. Add a new function in in the turbo module spec interface : `subtract(a: number, b: number): number;`
3.  In example project run : `pod install`
4. In Xcode open your module file. You should see a warning message. The message is telling that your module does not respect the interface generated by codegen
<img width="797" alt="image" src="https://user-images.githubusercontent.com/9041221/186721764-0119380a-00ba-488e-86be-e8c4ca8812a0.png">
5. Click on "Fix". It should generate the new `subtract` method
<img width="516" alt="image" src="https://user-images.githubusercontent.com/9041221/186721907-119297e9-278d-4851-bac0-fa8078e3df50.png">

#### Turbo module with backward compatibility

Same process. But select 'backward compat' option : 
<img width="427" alt="image" src="https://user-images.githubusercontent.com/9041221/186723673-cda52f32-6f01-4491-8296-b8de1eec9e0b.png">


To keep the backward compatibility, the hack is to create a remap method that calls the one generated by Xcode.
```objective-c
RCT_REMAP_METHOD(subtract,
                 subtractWithA:(double)a  withB:(double)b
                 withResolver:(RCTPromiseResolveBlock)resolve
                 withRejecter:(RCTPromiseRejectBlock)reject)
{
    [self subtract:a b:b resolve:resolve reject:reject];
}
```
