### PR TITLE
To make subfolder's exports visible.

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -9,7 +9,7 @@
   "source": "src/index",
   "files": [
     "src",
-    "lib",
+    "lib/**/*",
     "android",
     "ios",
     "cpp",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The original template put all things in `src/index.tsx` and exported everything from there. As the package grows, we might want to organize things into subfolders. e.g.
```
/src/native/index.ts
/src/utils/index.ts
/src/index.tsx
```
and in `/src/index.tsx` we have
```
export * from './native';
export * from './utils';
```
so that all the members exported from `/src/native/index.ts` and `/src/utils/index.ts` would finally be exported through `/src/index.tsx` and should be accessible by this package's consumer project.

There is no problem doing so when this package is "local". (e.g. when we run `/example` provided along with the package by the template, this package is "local".) But if an outside project installed this package from `npmjs` (or `yarnpkg`) and `import {...} from '<this-package>';`, all the exported members became invisible.

To fix this issue, replace `"lib"` with `"lib/**/*"` in `package.json`'s `"files"` entry.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Verify this fix as described in the above `Summary` section.
