### PR TITLE
fix: remove babel-eslint parser due to lack of support for typescript

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.7",
-    "@babel/eslint-parser": "^7.18.2",
     "@commitlint/config-conventional": "^17.0.2",
     "@react-native-community/eslint-config": "^3.0.2",
     "@release-it/conventional-changelog": "^5.0.0",
@@ -105,7 +104,6 @@
   },
   "eslintConfig": {
     "root": true,
-    "parser": "@babel/eslint-parser",
     "extends": [
       "@react-native-community",
       "prettier"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR removes `@babel/eslint-parser` as it causes Eslint to crash.
It's crashing because babel eslint parser doesn't support typescript rules.
For more details about that you can [visit babel eslint package](https://www.npmjs.com/package/@babel/eslint-parser#typescript)
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
- Generate new library
- Add some blank space in some js file
