### PR TITLE
feat: make year dynamic

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -577,6 +577,7 @@ async function create(argv: yargs.Arguments<any>) {
     repo: repoUrl,
     example,
     turborepo,
+    year: new Date().getFullYear(),
   };
 
   const copyDir = async (source: string, dest: string) => {

--- a/packages/create-react-native-library/templates/common/LICENSE
+++ b/packages/create-react-native-library/templates/common/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 <%- author.name -%>
+Copyright (c) <%- year -%> <%- author.name -%>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Summary
We are manually updating year when it can be dynamic.

### Test plan
* The following command should not fail.
```
node packages/create-react-native-library/bin/create-react-native-library sample-module
```
* Year in LICENSE should be the device's year.

