### PR TITLE
Backport androidmk

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -65,6 +65,12 @@ const SWIFT_FILES = {
   view_legacy: path.resolve(__dirname, '../templates/swift-view-legacy'),
 } as const;
 
+const CPP_VIEW_FILES = {
+  // view_legacy does NOT need component registration
+  view_mixed: path.resolve(__dirname, '../templates/cpp-view-mixed'),
+  view_new: path.resolve(__dirname, '../templates/cpp-view-new'),
+} as const;
+
 type ArgName =
   | 'slug'
   | 'description'
@@ -681,6 +687,12 @@ async function create(argv: yargs.Arguments<any>) {
     if (options.project.cpp) {
       await copyDir(CPP_FILES, folder);
       await fs.remove(path.join(folder, 'ios', `${options.project.name}.m`));
+    }
+
+    if (moduleType === 'view') {
+      if (arch === 'new' || arch === 'mixed') {
+        await copyDir(CPP_VIEW_FILES[`${moduleType}_${arch}`], folder);
+      }
     }
   }
 

--- a/packages/create-react-native-library/templates/cpp-view-mixed/android/Android.mk
+++ b/packages/create-react-native-library/templates/cpp-view-mixed/android/Android.mk
@@ -1,0 +1,45 @@
+THIS_DIR := $(call my-dir)
+
+include $(REACT_ANDROID_DIR)/Android-prebuilt.mk
+
+include ${GENERATED_SRC_DIR}/codegen/jni/Android.mk
+
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(THIS_DIR)
+
+# Define the library name here.
+LOCAL_MODULE := ${CODEGEN_MODULE_NAME}_registration
+
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+
+LOCAL_SHARED_LIBRARIES := \
+  libfabricjni \
+  libfbjni \
+  libglog \
+  libjsi \
+  libreact_codegen_rncore \
+  libreact_codegen_${CODEGEN_MODULE_NAME} \
+  libreact_debug \
+  libreact_nativemodule_core \
+  libreact_render_componentregistry \
+  libreact_render_core \
+  libreact_render_debug \
+  libreact_render_graphics \
+  librrc_view \
+  libruntimeexecutor \
+  libturbomodulejsijni \
+  libyoga
+
+ifneq ($(filter $(call modules-get-list),folly_runtime),)
+  LOCAL_SHARED_LIBRARIES += libfolly_runtime # since react-native@0.69
+else
+  LOCAL_SHARED_LIBRARIES += libfolly_futures libfolly_json # react-native@0.68
+endif
+
+LOCAL_CFLAGS := \
+  -DLOG_TAG=\"ReactNative\" \
+  -DCODEGEN_COMPONENT_DESCRIPTOR_H="<react/renderer/components/${CODEGEN_MODULE_NAME}/ComponentDescriptors.h>"
+LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+
+include $(BUILD_SHARED_LIBRARY)

--- a/packages/create-react-native-library/templates/cpp-view-mixed/android/registration.cpp
+++ b/packages/create-react-native-library/templates/cpp-view-mixed/android/registration.cpp
@@ -1,0 +1,18 @@
+#include <CoreComponentsRegistry.h>
+#include CODEGEN_COMPONENT_DESCRIPTOR_H
+
+namespace facebook {
+namespace react {
+
+void registerProviders() {
+    auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+    providerRegistry->add(concreteComponentDescriptorProvider<<%- project.name + 'View' -%>ComponentDescriptor>());
+}
+
+}
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    facebook::react::registerProviders();
+    return JNI_VERSION_1_6;
+}

--- a/packages/create-react-native-library/templates/cpp-view-new/android/Android.mk
+++ b/packages/create-react-native-library/templates/cpp-view-new/android/Android.mk
@@ -1,0 +1,45 @@
+THIS_DIR := $(call my-dir)
+
+include $(REACT_ANDROID_DIR)/Android-prebuilt.mk
+
+include ${GENERATED_SRC_DIR}/codegen/jni/Android.mk
+
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(THIS_DIR)
+
+# Define the library name here.
+LOCAL_MODULE := ${CODEGEN_MODULE_NAME}_registration
+
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+
+LOCAL_SHARED_LIBRARIES := \
+  libfabricjni \
+  libfbjni \
+  libglog \
+  libjsi \
+  libreact_codegen_rncore \
+  libreact_codegen_${CODEGEN_MODULE_NAME} \
+  libreact_debug \
+  libreact_nativemodule_core \
+  libreact_render_componentregistry \
+  libreact_render_core \
+  libreact_render_debug \
+  libreact_render_graphics \
+  librrc_view \
+  libruntimeexecutor \
+  libturbomodulejsijni \
+  libyoga
+
+ifneq ($(filter $(call modules-get-list),folly_runtime),)
+  LOCAL_SHARED_LIBRARIES += libfolly_runtime # since react-native@0.69
+else
+  LOCAL_SHARED_LIBRARIES += libfolly_futures libfolly_json # react-native@0.68
+endif
+
+LOCAL_CFLAGS := \
+  -DLOG_TAG=\"ReactNative\" \
+  -DCODEGEN_COMPONENT_DESCRIPTOR_H="<react/renderer/components/${CODEGEN_MODULE_NAME}/ComponentDescriptors.h>"
+LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+
+include $(BUILD_SHARED_LIBRARY)

--- a/packages/create-react-native-library/templates/cpp-view-new/android/registration.cpp
+++ b/packages/create-react-native-library/templates/cpp-view-new/android/registration.cpp
@@ -1,0 +1,18 @@
+#include <CoreComponentsRegistry.h>
+#include CODEGEN_COMPONENT_DESCRIPTOR_H
+
+namespace facebook {
+namespace react {
+
+void registerProviders() {
+    auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+    providerRegistry->add(concreteComponentDescriptorProvider<<%- project.name + 'View' -%>ComponentDescriptor>());
+}
+
+}
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    facebook::react::registerProviders();
+    return JNI_VERSION_1_6;
+}

--- a/packages/create-react-native-library/templates/java-view-mixed/android/src/newarch/{%- project.name %}ViewManagerSpec.java
+++ b/packages/create-react-native-library/templates/java-view-mixed/android/src/newarch/{%- project.name %}ViewManagerSpec.java
@@ -8,8 +8,15 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerDelegate;
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerInterface;
+import com.facebook.soloader.SoLoader;
 
 public abstract class <%- project.name -%>ViewManagerSpec<T extends View> extends SimpleViewManager<T> implements <%- project.name -%>ViewManagerInterface<T> {
+  static {
+    if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+      SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION);
+    }
+  }
+
   private final ViewManagerDelegate<T> mDelegate;
 
   public <%- project.name -%>ViewManagerSpec() {

--- a/packages/create-react-native-library/templates/java-view-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}ViewManager.java
+++ b/packages/create-react-native-library/templates/java-view-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}ViewManager.java
@@ -11,11 +11,18 @@ import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerDelegate;
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerInterface;
+import com.facebook.soloader.SoLoader;
 
 @ReactModule(name = <%- project.name -%>ViewManager.NAME)
 public class <%- project.name -%>ViewManager extends SimpleViewManager<<%- project.name -%>View> implements <%- project.name -%>ViewManagerInterface<<%- project.name -%>View> {
 
   public static final String NAME = "<%- project.name -%>View";
+
+  static {
+    if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+      SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION);
+    }
+  }
 
   private final ViewManagerDelegate<<%- project.name -%>View> mDelegate;
 

--- a/packages/create-react-native-library/templates/kotlin-view-mixed/android/src/newarch/{%- project.name %}ViewManagerSpec.kt
+++ b/packages/create-react-native-library/templates/kotlin-view-mixed/android/src/newarch/{%- project.name %}ViewManagerSpec.kt
@@ -7,6 +7,7 @@ import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerDelegate
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerInterface
+import com.facebook.soloader.SoLoader
 
 abstract class <%- project.name -%>ViewManagerSpec<T : View> : SimpleViewManager<T>(), <%- project.name -%>ViewManagerInterface<T> {
   private val mDelegate: ViewManagerDelegate<T>
@@ -17,5 +18,13 @@ abstract class <%- project.name -%>ViewManagerSpec<T : View> : SimpleViewManager
 
   override fun getDelegate(): ViewManagerDelegate<T>? {
     return mDelegate
+  }
+
+  companion object {
+    init {
+      if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+        SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION)
+      }
+    }
   }
 }

--- a/packages/create-react-native-library/templates/kotlin-view-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}ViewManager.kt
+++ b/packages/create-react-native-library/templates/kotlin-view-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}ViewManager.kt
@@ -8,6 +8,7 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerInterface
 import com.facebook.react.viewmanagers.<%- project.name -%>ViewManagerDelegate
+import com.facebook.soloader.SoLoader
 
 @ReactModule(name = <%- project.name -%>ViewManager.NAME)
 class <%- project.name -%>ViewManager : SimpleViewManager<<%- project.name -%>View>(),
@@ -37,5 +38,11 @@ class <%- project.name -%>ViewManager : SimpleViewManager<<%- project.name -%>Vi
 
   companion object {
     const val NAME = "<%- project.name -%>View"
+
+    init {
+      if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+        SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION)
+      }
+    }
   }
 }

--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -27,6 +27,31 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 <% } -%>
 
+<% if (project.view && (project.arch === "new" || project.arch === "mixed")) { -%>
+import groovy.json.JsonSlurper
+
+// https://github.com/callstack/react-native-builder-bob/discussions/359
+def registrationCompat = {
+  def reactNativeManifest = file("$projectDir/../node_modules/react-native/package.json").exists()
+    ? file("$projectDir/../node_modules/react-native/package.json") // developer mode, to run example app
+    : file("$projectDir/../../react-native/package.json")
+  def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
+  // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.71
+  // Use Android.mk for compatibility with react-native@0.68/0.69
+  reactNativeVersion.matches('(0.68.*|0.69.*)')
+}()
+
+def codegenViewLibraryName = "<%- project.name + 'View' -%>"
+def codegenViewModuleName = {
+  // Autolink for Fabric uses codegenConfig.name in package.json since react-native@0.70
+  // Use codegenViewLibraryName for compatibility with react-native@0.68/0.69
+  def libraryManifestJson = new JsonSlurper().parseText(file("$projectDir/../package.json").text)
+  registrationCompat ? codegenViewLibraryName : libraryManifestJson.codegenConfig.name
+}()
+<% } -%>
+
+def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"
 }
@@ -40,7 +65,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-<% if (project.cpp) { -%>
+<% if (project.cpp || (project.view && (project.arch === "new" || project.arch === "mixed"))) { -%>
   ndkVersion getExtOrDefault("ndkVersion")
 <% } -%>
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
@@ -49,11 +74,33 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+<% if (project.view && (project.arch === "new" || project.arch === "mixed")) { -%>
+    buildConfigField "String", "CODEGEN_MODULE_REGISTRATION", (isNewArchitectureEnabled() && registrationCompat ? "\"${codegenViewModuleName}_registration\"" : "null")
+<% } -%>
 <% if (project.cpp) { -%>
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
         abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
+      }
+    }
+<% } else if (project.view && (project.arch === "new" || project.arch === "mixed")) { -%>
+    if (isNewArchitectureEnabled() && registrationCompat) {
+      def reactAndroidProject = project(':ReactAndroid')
+      externalNativeBuild {
+        ndkBuild {
+          arguments "APP_PLATFORM=android-21",
+                    "APP_STL=c++_shared",
+                    "NDK_TOOLCHAIN_VERSION=clang",
+                    "GENERATED_SRC_DIR=$buildDir/generated/source", // for react_codegen_* in this library's codegen/jni
+                    "PROJECT_BUILD_DIR=${appProject.buildDir}", // for REACT_NDK_EXPORT_DIR in ReactAndroid's Android-prebuilt.mk
+                    "REACT_ANDROID_DIR=${reactAndroidProject.projectDir}",
+                    "REACT_ANDROID_BUILD_DIR=${reactAndroidProject.buildDir}",
+                    "CODEGEN_MODULE_NAME=$codegenViewModuleName"
+          cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
+          cppFlags "-std=c++17"
+          targets "${codegenViewModuleName}_registration"
+        }
       }
     }
 <% } -%>
@@ -62,6 +109,15 @@ android {
   externalNativeBuild {
     cmake {
       path "CMakeLists.txt"
+    }
+  }
+<% } else if (project.view && (project.arch === "new" || project.arch === "mixed")) { -%>
+  if (isNewArchitectureEnabled() && registrationCompat) {
+    // We configure the NDK build only if you decide to opt-in for the New Architecture.
+    externalNativeBuild {
+      ndkBuild {
+        path "Android.mk"
+      }
     }
   }
 <% } -%>
@@ -130,7 +186,11 @@ dependencies {
 if (isNewArchitectureEnabled()) {
   react {
     jsRootDir = file("../src/")
+<% if (project.view && (project.arch === "new" || project.arch === "mixed")) { %>
+    libraryName = codegenViewLibraryName
+<% } else { -%>
     libraryName = "<%- project.view ? project.name + 'View' : project.name -%>"
+<% } -%>
     codegenJavaPackageName = "com.<%- project.package -%>"
   }
 }


### PR DESCRIPTION
### Summary

Ref: https://github.com/callstack/react-native-builder-bob/discussions/359

[`Fabric` was introduced at react-native@0.68](https://reactnative.dev/blog/2022/03/30/version-068#opting-in-to-the-new-architecture), and [full CMake support was introduced at react-native@0.71](https://reactnative.dev/blog/2022/09/05/version-070#full-cmake-support-for-android-builds)

We are working on fabric packages for 0.69 and need fabric template with `Android.mk`

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

```sh
$ $PATH_TO_BOB_PROJECT/packages/create-react-native-library/bin/create-react-native-library create fabric-compat
...
✔ What type of library do you want to develop? › Fabric view with backward compat
...
$ pushd fabric-compat && yarn install && yalc publish && popd
# Or npx react-native@0.68.5 
$ npx react-native@0.69.4 init MyApp --version 0.69.4
$ cd MyApp && yalc add react-native-fabric-compat && yarn install
# Open MyApp/android/gradle.properties and set newArchEnabled=true
$ yarn android
```
