### PR TITLE
fix: failure noinspection version for 0.69.4

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -121,7 +121,7 @@ dependencies {
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-native"
+  implementation "com.facebook.react:react-native:+"
 <% if (project.kotlin) { -%>
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 <% } -%>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix https://github.com/callstack/react-native-builder-bob/issues/361 which is introduced by https://github.com/callstack/react-native-builder-bob/commit/4eff3ebfcbbb1bc4961c5567ea4d1e75d3c5a72d

According to [outage postmortem](https://reactnative.dev/blog/2023/01/27/71rc1-android-outage-postmortem), we could revert the noinspection version `+` back for react-native@0.70.*

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
