### PR TITLE
fix: remove extra class-props babel plugin

### DIFF
--- a/packages/react-native-builder-bob/src/utils/compile.ts
+++ b/packages/react-native-builder-bob/src/utils/compile.ts
@@ -90,9 +90,6 @@ export default async function compile({
                 require.resolve('@babel/preset-typescript'),
                 require.resolve('@babel/preset-flow'),
               ],
-              plugins: [
-                require.resolve('@babel/plugin-proposal-class-properties'),
-              ],
             }),
       });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The`@babel/plugin-proposal-class-properties` no longer needs to be explicitly added, as it is now incorporated into `@babel/preset-env`. You can see this in a freshly generated RN library by adding `debug: true` to this default configuration:

```
% yarn bob build
yarn run v1.22.19
$ .../rnlib/node_modules/.bin/bob build
ℹ Building target commonjs
ℹ Cleaning up previous build at lib/commonjs
ℹ Compiling 1 files in src with babel
@babel/preset-env: `DEBUG` option

Using targets:
{
  "chrome": "108",
  "edge": "108",
  "firefox": "108",
  "ios": "15.6",
  "node": "16",
  "safari": "15.6",
  "samsung": "19"
}

Using modules transform: commonjs

Using plugins:
  proposal-class-static-block { ios, node < 16.11, safari }
  proposal-private-property-in-object { node < 16.9 }
  syntax-class-properties                             <----
  syntax-numeric-separator
  syntax-nullish-coalescing-operator
  proposal-optional-chaining { node < 16.9 }
  syntax-json-strings
  syntax-optional-catch-binding
  transform-parameters { ios, safari }
  syntax-async-generators
  syntax-object-rest-spread
  proposal-export-namespace-from { ios, safari }
  transform-modules-commonjs
  proposal-dynamic-import

...
```

Removing this duplicate entry ensures the optimal application of transforms within the preset-env space. This was discovered while attempting to update `react-native-svg`, which has a pathologic case in their `Symbol.tsx` that causes a babel parser error that is resolved when this entry is removed:

```
Error: .../react-native-svg/src/elements/Symbol.tsx: We don't know what to do with this node type. We were previously a Statement but we can't fit in here?
    at NodePath.insertBefore (.../react-native-svg/node_modules/@babel/traverse/lib/path/modification.js:57:11)
    ...
    at async.call.result.err.err (.../react-native-svg/node_modules/gensync/index.js:223:11) {
  code: 'BABEL_TRANSFORM_ERROR'
```

### Test plan

I reproduced the minimal problem space at https://github.com/merrywhether/rnlib, and also verified that this allows `react-native-svg` to build against `react-native-builder-bob@0.20.0` (after upgrading it from `@react-native-community/bob@0.9.7`).

Closes #154.
Unblocks https://github.com/software-mansion/react-native-svg/pull/1993.
