### PR TITLE
refactor: remove unnecessary babel-plugin-module-resolver

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -33,9 +33,7 @@ const PACKAGES_TO_REMOVE = [
   'typescript',
 ];
 
-const PACKAGES_TO_ADD_DEV = {
-  'babel-plugin-module-resolver': '^4.1.0',
-};
+const PACKAGES_TO_ADD_DEV = {};
 
 const PACKAGES_TO_ADD_WEB = {
   'react-dom': '18.1.0',

--- a/packages/create-react-native-library/templates/example-legacy/example/babel.config.js
+++ b/packages/create-react-native-library/templates/example-legacy/example/babel.config.js
@@ -1,17 +1,3 @@
-const path = require('path');
-const pak = require('../package.json');
-
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: [
-    [
-      'module-resolver',
-      {
-        extensions: ['.tsx', '.ts', '.js', '.json'],
-        alias: {
-          [pak.name]: path.join(__dirname, '..', pak.source),
-        },
-      },
-    ],
-  ],
 };

--- a/packages/create-react-native-library/templates/expo-library/example/babel.config.js
+++ b/packages/create-react-native-library/templates/expo-library/example/babel.config.js
@@ -1,22 +1,6 @@
-const path = require('path');
-const pak = require('../package.json');
-
 module.exports = function (api) {
   api.cache(true);
-
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      [
-        'module-resolver',
-        {
-          extensions: ['.tsx', '.ts', '.js', '.json'],
-          alias: {
-            // For development, we want to alias the library to the source
-            [pak.name]: path.join(__dirname, '..', pak.source),
-          },
-        },
-      ],
-    ],
   };
 };


### PR DESCRIPTION
### Summary

As far as I test, `babel-plugin-module-resolver` has been unnecessary since react-native@0.69.4

And it caused some problem when migerating some legacy library, e.g. https://github.com/react-native-linear-gradient/react-native-linear-gradient

### Test plan