### PR TITLE
fix(templates/common): add src for generated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ yarn add --dev react-native-builder-bob
    "main": "lib/commonjs/index.js",
    "module": "lib/module/index.js",
    "react-native": "src/index.ts",
-   "types": "lib/typescript/index.d.ts",
+   "types": "lib/typescript/src/index.d.ts",
    "files": [
      "lib/",
      "src/"

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -4,7 +4,7 @@
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Generated files for types are under `typescript/src` not `typescript`