### PR TITLE
feat: add C files linking to .podspec file template

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "<%- repo -%>.git", :tag => "#{s.version}" }
 
 <% if (project.cpp) { -%>
-  s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp}"
+  s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp,c}"
 <% } else if (project.swift) { -%>
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 <% } else { -%>

--- a/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "<%- repo -%>.git", :tag => "#{s.version}" }
 
 <% if (project.cpp) { -%>
-  s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp,c}"
+  s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{hpp,cpp,c,h}"
 <% } else if (project.swift) { -%>
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 <% } else { -%>


### PR DESCRIPTION
### Summary

This PR adds support for linking **C files** on iOS.

When creating module with C++ template, files with `.c` extension were not linked correctly.