### PR TITLE
feat(android): gradle namespace support for AGP versions >7.3

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -64,7 +64,16 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["<%- project.name -%>_" + name]).toInteger()
 }
 
+def isAGPVersionGreaterThan(version) {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  return agpVersion > version
+}
+
 android {
+  if (isAGPVersionGreaterThan(7)) {
+    namespace "com.<%- project.package -%>"
+  }
+
 <% if (project.cpp || (project.view && (project.arch === "new" || project.arch === "mixed"))) { -%>
   ndkVersion getExtOrDefault("ndkVersion")
 <% } -%>


### PR DESCRIPTION
### Summary

Resolves #394 

### Test plan

> The ideal way this should be tested is with the Android Gradle Plugin 8.0 but it's planned to be introduced with React Native 0.73.

1. Create a new library that includes native Android code (Native Module > Java & Obj-c for instance).
2. Make sure you are able to build the example app on Android.
3. Also make sure you are able to create a release variant of the example app.

