### PR TITLE
feat: verify that the package.json fields point to correct path

### DIFF
--- a/packages/react-native-builder-bob/src/targets/commonjs.ts
+++ b/packages/react-native-builder-bob/src/targets/commonjs.ts
@@ -33,5 +33,6 @@ export default async function build({
     output,
     modules: 'commonjs',
     report,
+    field: 'main',
   });
 }

--- a/packages/react-native-builder-bob/src/targets/module.ts
+++ b/packages/react-native-builder-bob/src/targets/module.ts
@@ -33,5 +33,6 @@ export default async function build({
     output,
     modules: false,
     report,
+    field: 'module',
   });
 }

--- a/packages/react-native-builder-bob/src/utils/logger.ts
+++ b/packages/react-native-builder-bob/src/utils/logger.ts
@@ -3,7 +3,16 @@ import kleur from 'kleur';
 const logger =
   (type: string, color: Function) =>
   (...messages: unknown[]) => {
-    console.log(color(kleur.bold(type)), ...messages);
+    console.log(
+      color(kleur.bold(type)),
+      ...messages.map((message) => {
+        if (typeof message === 'string') {
+          return message.split('\n').join(`\n  `);
+        } else {
+          return message;
+        }
+      })
+    );
   };
 
 export const info = logger('ℹ', kleur.blue);


### PR DESCRIPTION
### Summary

After initial project setup, it's possible that the location of built files may diverge from value of package.json fields due to configuration changes. Previously it'd go unnoticed.

This adds additional checks after the files are built to ensure that such mismatches cause a build failure.

https://github.com/callstack/react-native-builder-bob/assets/1174278/25d1c427-da3e-4204-b49e-6754c1a316de

### Test plan

- Tested it in React Navigation & React Native Paper repos
