### PR TITLE
refactor: use RCT_EXPORT_METHOD instead of RCT_REMAP_METHOD

### DIFF
--- a/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.mm
+++ b/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.mm
@@ -7,10 +7,10 @@ RCT_EXPORT_MODULE()
 <% if (project.arch === 'legacy' || project.arch === 'mixed') { -%>
 // Example method
 // See // https://reactnative.dev/docs/native-modules-ios
-RCT_REMAP_METHOD(multiply,
-                 multiplyWithA:(double)a withB:(double)b
-                 withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(multiply:(double)a
+                  b:(double)b
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 {
 <% if (project.cpp) { -%>
     NSNumber *result = @(<%- project.package_cpp -%>::multiply(a, b));
@@ -20,29 +20,23 @@ RCT_REMAP_METHOD(multiply,
 
     resolve(result);
 }
-<% } -%>
 
+<% } -%>
 <% if (project.arch === 'new' || project.arch === 'mixed') { -%>
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 <% if (project.arch === 'new') { -%>
 - (NSNumber *)multiply:(double)a b:(double)b {
-<% } else { -%>
-- (void)multiply:(double)a b:(double)b resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-<% } -%>
 <% if (project.cpp) { -%>
     NSNumber *result = @(<%- project.package_cpp -%>::multiply(a, b));
 <% } else { -%>
     NSNumber *result = @(a * b);
 <% } -%>
 
-<% if (project.arch === 'new') { -%>
     return result;
-<% } else { -%>
-    resolve(result);
-<% } -%>
 }
 
+<% } -%>
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {


### PR DESCRIPTION
### Summary

Closes #414 
We were using `RCT_REMAP_METHOD` to register methods in the current architecture. This macro generates a new method from the given method and changes its signature.

I've changed it to `RCT_EXPORT_METHOD` and with this change, we are able to remove the duplicate implementation for mixed libraries.

### Test plan

These changes can potentially change these libraries: `current arch objc`, `new arch objc`, `new arch cpp`, `mixed arch objc`, `mixed arch cpp`. We need to make sure all of those libraries are generated properly and work well.
