### PR TITLE
fix: don't use deprecated package field in AndroidManifest on AGP >= 7.3

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -64,14 +64,28 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["<%- project.name -%>_" + name]).toInteger()
 }
 
-def isAGPVersionGreaterThan(version) {
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-  return agpVersion > version
+def supportsNamespace() {
+  def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+
+  // Namespace support was added in 7.3.0
+  if (major == 7 && minor >= 3) {
+    return true
+  }
+
+  return major >= 8
 }
 
 android {
-  if (isAGPVersionGreaterThan(7)) {
+  if (supportsNamespace()) {
     namespace "com.<%- project.package -%>"
+  } else {
+    sourceSets {
+      main {
+        manifest.srcFile "src/main/AndroidManifestDeprecated.xml"
+      }
+    }
   }
 
 <% if (project.cpp || (project.view && (project.arch === "new" || project.arch === "mixed"))) { -%>

--- a/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifest.xml
+++ b/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.<%- project.package -%>">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestDeprecated.xml
+++ b/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestDeprecated.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.<%- project.package -%>">
+</manifest>


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/callstack/react-native-builder-bob/pull/399

Currently there's a deprecation warning for the `package` field in `AndroidManifest.xml` when using Android Gradle Plugin >= 7.3.

This adds a separate `AndroidManifest` file that'll be used for older versions of Android Gradle Plugin to avoid the deprecation warning on newer versions.

### Test plan

- Verify CI passes
- Verify building and running various templates
