### PR TITLE
fix: rm mode check in registrationCompat

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -32,7 +32,11 @@ import groovy.json.JsonSlurper
 
 // https://github.com/callstack/react-native-builder-bob/discussions/359
 def registrationCompat = {
-  def reactNativeManifest = file("$projectDir/../../react-native/package.json")
+  // The new distribution model uses Maven Central https://reactnative.dev/blog/2023/01/12/version-071
+  def reactAndroidProject = rootProject.allprojects.find { it.name == 'ReactAndroid' }
+  if (reactAndroidProject == null) return false
+
+  def reactNativeManifest = file("${reactAndroidProject.projectDir}/../package.json")
   def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
   // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.70
   // Use Android.mk for compatibility with react-native@0.68/0.69

--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -32,9 +32,7 @@ import groovy.json.JsonSlurper
 
 // https://github.com/callstack/react-native-builder-bob/discussions/359
 def registrationCompat = {
-  def reactNativeManifest = file("$projectDir/../node_modules/react-native/package.json").exists()
-    ? file("$projectDir/../node_modules/react-native/package.json") // developer mode, to run example app
-    : file("$projectDir/../../react-native/package.json")
+  def reactNativeManifest = file("$projectDir/../../react-native/package.json")
   def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
   // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.70
   // Use Android.mk for compatibility with react-native@0.68/0.69


### PR DESCRIPTION
### Summary

`develop mode` condition is inspired by [`react-native-reanimated` build.gradle](https://github.com/software-mansion/react-native-reanimated/blob/main/android/build.gradle)

It uses the lock version of `react-native` dependency of library when compiling `example`

The lock version fails the build when there are different versions of `react-native` in each variant of examples

For example, https://github.com/Sunbreak/lottie-react-native/tree/compat-example

- [apps/fabric](https://github.com/Sunbreak/lottie-react-native/tree/compat-example/apps/fabric) use `react-native@0.71.11`
- [apps/fabric-compat](https://github.com/Sunbreak/lottie-react-native/tree/compat-example/apps/fabric) use `react-native@0.69.4`

### Test plan

https://github.com/lottie-react-native/lottie-react-native/pull/1057 is PR of lottie-react-native for compat with `react-native@0.69.4`