### PR TITLE
fix: use `AndroidManifest.xml` for older RN versions

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -80,10 +80,10 @@ def supportsNamespace() {
 android {
   if (supportsNamespace()) {
     namespace "com.<%- project.package -%>"
-  } else {
+
     sourceSets {
       main {
-        manifest.srcFile "src/main/AndroidManifestDeprecated.xml"
+        manifest.srcFile "src/main/AndroidManifestNew.xml"
       }
     }
   }

--- a/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifest.xml
+++ b/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.<%- project.package -%>">
 </manifest>

--- a/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestDeprecated.xml
+++ b/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestDeprecated.xml
@@ -1,3 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.<%- project.package -%>">
-</manifest>

--- a/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestNew.xml
+++ b/packages/create-react-native-library/templates/native-common/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>


### PR DESCRIPTION
### Summary

The React Native CLI relies on the filename `AndroidManifest.xml` to be able parse the package name. But we were using `AndroidManifestLegacy.xml` instead which broke the lib for older RN versions (AGP 7). This change makes it so that we use `AndroidManifest.xml` for older RN versions and `AndroidManifestNew.xml` for newer RN versions.

Fixes #429

### Test plan

- Create an app with RN 0.68 and install the library without these changes - see that `yarn android` fails
- Create an app with RN 0.68 and install the library with these changes - see that `yarn android` succeeds
- Create an app with latest RN and install the library with these changes - see that `yarn android` succeeds