### PR TITLE
feat(builder-bob): dont use npm bin to get tsc path

### DIFF
--- a/packages/react-native-builder-bob/package.json
+++ b/packages/react-native-builder-bob/package.json
@@ -53,7 +53,6 @@
     "json5": "^2.2.1",
     "kleur": "^4.1.4",
     "prompts": "^2.4.2",
-    "which": "^2.0.2",
     "yargs": "^17.5.1"
   },
   "optionalDependencies": {

--- a/packages/react-native-builder-bob/package.json
+++ b/packages/react-native-builder-bob/package.json
@@ -53,6 +53,7 @@
     "json5": "^2.2.1",
     "kleur": "^4.1.4",
     "prompts": "^2.4.2",
+    "which": "^2.0.2",
     "yargs": "^17.5.1"
   },
   "optionalDependencies": {

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -81,6 +81,16 @@ export default async function build({
 
     if (options?.tsc) {
       binary = path.resolve(root, options.tsc);
+
+      if (!(await fs.pathExists(binary))) {
+        throw new Error(
+          `The ${kleur.blue(
+            'tsc'
+          )} binary doesn't seem to be installed at ${kleur.blue(
+            binary
+          )}. Please specify the correct path in options or remove it to use the workspace's version.`
+        );
+      }
     } else {
       binary = 'npx';
     }


### PR DESCRIPTION
## Summary

Closes #434
The builder bob typescript build phase uses `yarn bin` and `npm bin` commands to locate the `tsc`. However, the `npm bin` command is removed with npm 9.0. Please see: https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/

## Test plan

> Both of the test cases start with the following steps:
1. Clone the repo and cd into `packages/react-native-builder-bob`
2. Run `yarn prepack` to build the builder bob.
3. Run `npm link`
4. Create a new project with `npx create-react-native-library@latest my-awesome-project`. You can select `javascript` as the type.
5. Run `npm link react-native-builder-bob` to link the project.

### Resolve `tsc` automatically

1. Run `npm run prepack` to verify the typescript compilation step works properly.
2. Run `yarn prepack` to verify the typescript compilation step works properly.
3. Run `pnpm prepack` to verify the typescript compilation step works properly.

### Resolve `tsc` using the builder bob config

1. Go to the `package.json` file of the project you've generated.
2. Go to the `react-native-builder-bob` section and specify the tsc binary as following: (the `tsc` line needs to be added.)
```json
  "react-native-builder-bob": {
    "source": "src",
    "output": "lib",
    "targets": [
      "commonjs",
      "module",
      [
        "typescript",
        {
          "project": "tsconfig.build.json",
          "tsc": "./node_modules/.bin/tsc"
        }
      ]
    ]
  }
```
3. Run `npm run prepack` to verify the typescript compilation step works properly.
4. Run `yarn prepack` to verify the typescript compilation step works properly.
5. Run `pnpm prepack` to verify the typescript compilation step works properly.


