### PR TITLE
Feature: Allow bob.config.cjs

### DIFF
--- a/packages/react-native-builder-bob/src/index.ts
+++ b/packages/react-native-builder-bob/src/index.ts
@@ -18,7 +18,7 @@ const { name, version } = require('../package.json');
 
 const root = process.cwd();
 const explorer = cosmiconfigSync(name, {
-  searchPlaces: ['package.json', `bob.config.js`],
+  searchPlaces: ['package.json', `bob.config.js`, 'bob.config.cjs'],
 });
 
 const FLOW_PRGAMA_REGEX = /\*?\s*@(flow)\b/m;


### PR DESCRIPTION
### Summary

I have a library configured with `"type": "module"`. This means that I need to provide `bob.config.cjs`, as `.js` extensions won't do. That config file needs to be explicitly added to the cosmicConfig