### PR TITLE
chore: bump the engine node version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/react-navigation/react-navigation.git"
   },
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "packageManager": "^yarn@1.22.15",
   "scripts": {

--- a/packages/create-react-native-library/babel.config.js
+++ b/packages/create-react-native-library/babel.config.js
@@ -3,7 +3,7 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: { node: '16' },
+        targets: { node: '18' },
       },
     ],
     '@babel/preset-typescript',

--- a/packages/create-react-native-library/package.json
+++ b/packages/create-react-native-library/package.json
@@ -32,7 +32,7 @@
     "templates"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -90,7 +90,7 @@
     "react-native": "*"
   },
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "packageManager": "^yarn@1.22.15",
   "jest": {

--- a/packages/react-native-builder-bob/babel.config.js
+++ b/packages/react-native-builder-bob/babel.config.js
@@ -3,7 +3,7 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: { node: '16' },
+        targets: { node: '18' },
       },
     ],
     '@babel/preset-typescript',

--- a/packages/react-native-builder-bob/package.json
+++ b/packages/react-native-builder-bob/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-native-builder-bob/src/utils/compile.ts
+++ b/packages/react-native-builder-bob/src/utils/compile.ts
@@ -107,7 +107,7 @@ export default async function compile({
                         'not android <= 4.4',
                         'not samsung <= 4',
                       ],
-                      node: '16',
+                      node: '18',
                     },
                     useBuiltIns: false,
                     modules,


### PR DESCRIPTION
### Summary

Node 16 LTS has [reached EOL](https://nodejs.org/en/blog/announcements/nodejs16-eol). And some libraries are dropping the support for it already. In order to support the transition to Node 18 and make sure everything works properly, we can change all the minimum engine versions to 18.

### Test plan

> This needs to be tested with a pure Javascript library which uses Expo, and a library with native code which uses the CLI.

1. Create a new library using `npx create-react-native-library some-cool-name`.
2. Complete creating the library and install the dependencies
3. Build the example app and make sure your library works properly.
4. Run `yarn prepack` to make sure your library is building properly.
