### PR TITLE
fix: fix locating `tsc` in yarn 3 workspaces

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
-import spawn from 'cross-spawn';
 import path from 'path';
 import https from 'https';
+import { spawn } from './spawn';
 
 const FILES_TO_DELETE = [
   '__tests__',
@@ -78,26 +78,9 @@ export default async function generateExampleApp({
       : // `npx create-expo-app example --no-install`
         ['create-expo-app@latest', directory, '--no-install'];
 
-  await new Promise((resolve, reject) => {
-    const child = spawn('npx', args, {
-      cwd: dest,
-      env: { ...process.env, npm_config_yes: 'true' },
-    });
-
-    let stderr = '';
-
-    child.stderr?.setEncoding('utf8');
-    child.stderr?.on('data', (data) => {
-      stderr += data;
-    });
-
-    child.once('error', reject);
-    child.once('close', resolve);
-    child.once('exit', (code) => {
-      if (code === 1) {
-        reject(new Error(stderr));
-      }
-    });
+  await spawn('npx', args, {
+    cwd: dest,
+    env: { ...process.env, npm_config_yes: 'true' },
   });
 
   // Remove unnecessary files and folders

--- a/packages/create-react-native-library/src/utils/spawn.ts
+++ b/packages/create-react-native-library/src/utils/spawn.ts
@@ -1,0 +1,29 @@
+import crossSpawn from 'cross-spawn';
+
+export const spawn = async (...args: Parameters<typeof crossSpawn>) => {
+  return new Promise<string>((resolve, reject) => {
+    const child = crossSpawn(...args);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (data) => {
+      stdout += data;
+    });
+
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (data) => {
+      stderr += data;
+    });
+
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(stderr.trim()));
+      }
+    });
+  });
+};


### PR DESCRIPTION
### Summary

With Yarn 3, the aliases for binaries only seem to exist at the monorepo root `node_modules`, so the current logic fails to find `tsc`. This change uses `yarn bin tsc` to get the correct location for the `tsc` binary.

### Test plan

Tested in the React Navigation monorepo
