### PR TITLE
fix: remove unused cmake abiFilters

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -75,7 +75,6 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
-        abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
       }
     }
 <% } -%>


### PR DESCRIPTION
### Summary

> `cmake.abiFilters` specifies the Application Binary Interfaces (ABI) that Gradle should build outputs for. The ABIs that Gradle packages into your APK are determined by `android.defaultConfig.ndk.abiFilter` [link](https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/ExternalNativeCmakeOptions)

- Support for C++ module was introduced at https://github.com/callstack/react-native-builder-bob/commit/6588c5c1caf7e2f17d54f3abd0b5c812f92a9ee2 three years ago
- React Native application template instroduced `reactNativeArchitectures` since https://github.com/facebook/react-native/commit/0f39a1076dc154995a2db79352adc36452f46210 two years ago

### Test plan

None