### PR TITLE
fix: disable dummy codegen of rncore

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -158,7 +158,6 @@ dependencies {
 <% } -%>
 }
 
-<% if (project.arch === "new" || project.arch === "mixed") { -%>
 if (isNewArchitectureEnabled()) {
   react {
     jsRootDir = file("../src/")
@@ -166,4 +165,3 @@ if (isNewArchitectureEnabled()) {
     codegenJavaPackageName = "com.<%- project.package -%>"
   }
 }
-<% } -%>


### PR DESCRIPTION
### Summary

Without `react.jsRootDir`, **react-native-gradle-plugin** would generate `rncore` related code inside library's `buildDir` when `newArchEnabled` is true. And then duplicate class definition inside `ReactAndroid` like https://github.com/lottie-react-native/lottie-react-native/issues/1053

This impacts library's compatiblitiy with 0.68/0.69/0.70 because of direct dependent on source code of `ReactAndroid`

### Reproduce

- Generate `my-lib` legacy module and initialize dependency

```sh
npx create-react-native-library cpp-lib --react-native-version 0.70.13
✔ What is the name of the npm package? … react-native-cpp-lib
✔ What is the description for the package? … C++ library
✔ What is the name of package author? … Sunbreak
✔ What is the email address for the package author? … sunbreak.wang@gmail.com
✔ What is the URL for the package author? … https://github.com/Sunbreak
✔ What is the URL for the repository? … https://github.com/Sunbreak/react-native-cpp-lib
✔ What type of library do you want to develop? › Native module
✔ Which languages do you want to use? › C++ for Android & iOS
ℹ Using react-native@0.70.13 for the example
✔ Project created successfully at cpp-lib!

$ yarn
```

- set `newArchEnabled=true` in example/andorid
- compile android

```sh
$ yarn example android
...
ERROR:/Users/sunbreak/w/temp/cpp-lib/android/build/.transforms/bf9e6bfef630a6f77f22238c2792ba6f/transformed/classes/classes.dex: D8: Type com.facebook.react.viewmanagers.ActivityIndicatorViewManagerInterface is defined multiple times: /Users/sunbreak/w/temp/cpp-lib/android/build/.transforms/bf9e6bfef630a6f77f22238c2792ba6f/transformed/classes/classes.dex, /Users/sunbreak/w/temp/cpp-lib/example/node_modules/react-native/ReactAndroid/build/.transforms/eb9621efbac0f35e55ba3279bc90538a/transformed/classes/classes.dex
```

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
