### PR TITLE
fix: use prepack instead of prepare

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -37,7 +37,7 @@
 <% } else { -%>
     "clean": "del-cli lib",
 <% } -%>
-    "prepare": "bob build",
+    "prepack": "bob build",
     "release": "release-it"
   },
   "keywords": [


### PR DESCRIPTION
### Summary

Since Yarn v2 and upwards [doesn't support `prepare` script](https://yarnpkg.com/advanced/lifecycle-scripts) anymore I believe `prepack` should be used in the template to run `bob build` on install.

[This comment](https://github.com/callstack/react-native-builder-bob/issues/13#issuecomment-1620011941) says this should already be set but it wasn't in my case.
