### PR TITLE
chore: remove CMake warning

### DIFF
--- a/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
+++ b/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
+project(<%- project.name -%>)
 
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
### Summary

Removes CMake warning.

Before:
```
MacBook-Pro:react-native-sample davidangulo$ yarn example android
info Starting JS server...
info Launching emulator...
info Successfully launched emulator.
info Installing the app...

> Task :react-native-sample:configureCMakeDebug[arm64-v8a]
C/C++: CMake Warning (dev) in CMakeLists.txt:
C/C++:   No project() command is present.  The top-level CMakeLists.txt file must
C/C++:   contain a literal, direct call to the project() command.  Add a line of
C/C++:   code such as
C/C++:     project(ProjectName)
C/C++:   near the top of the file, but after cmake_minimum_required().
C/C++:   CMake is pretending there is a "project(Project)" command on the first
C/C++:   line.
C/C++: This warning is for project developers.  Use -Wno-dev to suppress it.

> Task :react-native-sample:configureCMakeDebug[armeabi-v7a]
C/C++: CMake Warning (dev) in CMakeLists.txt:
C/C++:   No project() command is present.  The top-level CMakeLists.txt file must
C/C++:   contain a literal, direct call to the project() command.  Add a line of
C/C++:   code such as
C/C++:     project(ProjectName)
C/C++:   near the top of the file, but after cmake_minimum_required().
C/C++:   CMake is pretending there is a "project(Project)" command on the first
C/C++:   line.
C/C++: This warning is for project developers.  Use -Wno-dev to suppress it.

> Task :react-native-sample:configureCMakeDebug[x86]
C/C++: CMake Warning (dev) in CMakeLists.txt:
C/C++:   No project() command is present.  The top-level CMakeLists.txt file must
C/C++:   contain a literal, direct call to the project() command.  Add a line of
C/C++:   code such as
C/C++:     project(ProjectName)
C/C++:   near the top of the file, but after cmake_minimum_required().
C/C++:   CMake is pretending there is a "project(Project)" command on the first
C/C++:   line.
C/C++: This warning is for project developers.  Use -Wno-dev to suppress it.

> Task :react-native-sample:configureCMakeDebug[x86_64]
C/C++: CMake Warning (dev) in CMakeLists.txt:
C/C++:   No project() command is present.  The top-level CMakeLists.txt file must
C/C++:   contain a literal, direct call to the project() command.  Add a line of
C/C++:   code such as
C/C++:     project(ProjectName)
C/C++:   near the top of the file, but after cmake_minimum_required().
C/C++:   CMake is pretending there is a "project(Project)" command on the first
C/C++:   line.
C/C++: This warning is for project developers.  Use -Wno-dev to suppress it.

> Task :app:installDebug
Installing APK 'app-debug.apk' on 'Pixel_4_API_30(AVD) - 11' for :app:debug
Installed on 1 device.

BUILD SUCCESSFUL in 51s
```

After:
```
MacBook-Pro:react-native-sample davidangulo$ yarn example android
info JS server already running.
info Installing the app...

> Task :app:installDebug
Installing APK 'app-debug.apk' on 'Pixel_4_API_30(AVD) - 11' for :app:debug
Installed on 1 device.

BUILD SUCCESSFUL in 9s
```

### Test plan
```
yarn example android
```
