### PR TITLE
chore: use project identifier instead of generic

### DIFF
--- a/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
+++ b/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.4.1)
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 11)
 
-add_library(cpp
+add_library(<%- project.identifier -%>
             SHARED
             ../cpp/<%- project.identifier -%>.cpp
             cpp-adapter.cpp

--- a/packages/create-react-native-library/templates/java-library-legacy/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
+++ b/packages/create-react-native-library/templates/java-library-legacy/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
@@ -24,7 +24,7 @@ public class <%- project.name -%>Module extends ReactContextBaseJavaModule {
 
 <% if (project.cpp) { -%>
   static {
-    System.loadLibrary("cpp");
+    System.loadLibrary("<%- project.identifier -%>");
   }
 
   private static native double nativeMultiply(double a, double b);

--- a/packages/create-react-native-library/templates/java-library-mixed/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
+++ b/packages/create-react-native-library/templates/java-library-mixed/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
@@ -21,7 +21,7 @@ public class <%- project.name -%>Module extends <%- project.name -%>Spec {
 
 <% if (project.cpp) { -%>
   static {
-    System.loadLibrary("cpp");
+    System.loadLibrary("<%- project.identifier -%>");
   }
 
   public static native double nativeMultiply(double a, double b);

--- a/packages/create-react-native-library/templates/java-library-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
+++ b/packages/create-react-native-library/templates/java-library-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Module.java
@@ -21,7 +21,7 @@ public class <%- project.name -%>Module extends Native<%- project.name -%>Spec {
 
 <% if (project.cpp) { -%>
   static {
-    System.loadLibrary("cpp");
+    System.loadLibrary("<%- project.identifier -%>");
   }
 
   private static native double nativeMultiply(double a, double b);


### PR DESCRIPTION
### Summary

Doesn't really fix/improve anything, just a nitpick. `cpp` seems too generic. Just close if it's not a welcome change. Thanks!

### Test plan

```
yarn example android
```
