### PR TITLE
chore: remove npm publish warning

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -45,7 +45,10 @@
     "ios",
     "android"
   ],
-  "repository": "<%- repo -%>",
+  "repository": {
+    "type": "git",
+    "url": "git+<%- repo -%>.git"
+  },
   "author": "<%- author.name -%> <<%- author.email -%>> (<%- author.url -%>)",
   "license": "MIT",
   "bugs": {

--- a/packages/create-react-native-library/templates/common/tsconfig.build.json
+++ b/packages/create-react-native-library/templates/common/tsconfig.build.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "./tsconfig",
   "exclude": ["example"]


### PR DESCRIPTION
### Summary
Running `npm publish` shows a warning.

<img width="1123" alt="Screenshot 2023-12-05 at 02 19 55" src="https://github.com/callstack/react-native-builder-bob/assets/36528176/851601d5-9978-4660-8f8d-c39c8a3e2734">

----

It suggested running `npm pkg fix` which automatically makes the following changes.

<img width="692" alt="Screenshot 2023-12-05 at 02 21 17" src="https://github.com/callstack/react-native-builder-bob/assets/36528176/b655f798-7273-4497-8369-22f7d410df7e">

----

I assumed `git` is the default since most of the workflows are GitHub-specific.

Also, a nit where a remove an extra line break.

### Test plan

N/A
