### PR TITLE
fix: jsi no template error

### DIFF
--- a/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
+++ b/packages/create-react-native-library/templates/cpp-library/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4.1)
 project(<%- project.name -%>)
 
 set (CMAKE_VERBOSE_MAKEFILE ON)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 add_library(<%- project.identifier -%>
             SHARED


### PR DESCRIPTION
### Summary
```
error Failed to install the app. Command failed with exit code 1: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
Execution failed for task ':react-native-pkce-challenge:buildCMakeDebug[arm64-v8a]'.
mobile/android/../node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:1107:23 error: no template named 'enable_if_t' in namespace 'std'; did you mean 'enable_if'? typename = std::enable_if_t< ~~~~~^~~~~~~~~~~ enable_if
```

`enable_if_t` is used by JSI: https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/jsi/jsi/jsi.h#L1122

According to https://stackoverflow.com/questions/64281680/error-no-template-named-enable-if-t-in-namespace-std-did-you-mean-enable, the fix is to use C++14 or newer.

React Native JSI itself uses C++14: https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt#L6

### Test plan

Green CI.
