### PR TITLE
Update ci.yml : Using pod install instead of pod-install

### DIFF
--- a/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
+++ b/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
         run: |
-          yarn pod-install example/ios
+          cd example/ios && pod install
         env:
           NO_FLIPPER: 1
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Pod-install is not adding appropriate node version cause build to break in ci.

`yarn pod-install` adds `.xcode.env.local` as 
`export NODE_BINARY=/private/var/folders/pw/n0k7yhwx5lx99s1bswyxq1tc0000gp/T/xfs-713c155c/node`

Whereas `pod install` seems to be working fine.





### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
