### PR TITLE
chore: use java 17 and 6G max heap on workflows 

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -207,7 +207,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Finalize Android SDK
         if: env.android_build == 1 && env.turbo_cache_hit_android != 1

--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -226,6 +226,8 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build example (Android)
+        env:
+          JAVA_OPTS: "-XX:MaxHeapSize=6g"
         if: env.android_build == 1
         working-directory: ${{ env.work_dir }}
         run: |

--- a/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
+++ b/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Finalize Android SDK
         if: env.turbo_cache_hit != 1

--- a/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
+++ b/packages/create-react-native-library/templates/common/$.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build example for Android
+        env:
+          JAVA_OPTS: "-XX:MaxHeapSize=6g"
         run: |
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 


### PR DESCRIPTION
### Summary

Newer versions of Android Gradle Plugin requires Java 17 to work. We were using Java 11 on workflows. Upgraded them to use Java 17.
I've also noticed sometimes runners fails due to 2G max heap. I've set max heap to 6G.

### Test plan

Android related CI needs to pass.
