### PR TITLE
feat: add a dummy swift file to the example if the library uses swift

### DIFF
--- a/packages/create-react-native-library/src/add-dummy-swift-file.rb
+++ b/packages/create-react-native-library/src/add-dummy-swift-file.rb
@@ -1,0 +1,16 @@
+gem 'xcodeproj'
+require 'xcodeproj'
+
+project_path = ARGV[0]
+target_name = ARGV[1]
+project = Xcodeproj::Project.open(project_path)
+
+project.targets.each do |target|
+  if target.name == target_name
+    swift_file = File.join(project.path, '..', 'File.swift')
+    group = project.groups.select {|i| i.name == target_name }.first
+    file = group&.new_file(swift_file)
+    target.add_file_references([file])
+  end
+end
+project.save

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -682,6 +682,7 @@ async function create(argv: yargs.Arguments<any>) {
       projectName: options.project.name,
       arch,
       reactNativeVersion,
+      swift: options.project.swift,
     });
   }
 

--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -33,6 +33,11 @@ const PACKAGES_TO_REMOVE = [
   'typescript',
 ];
 
+const ADD_DUMMY_SWIFT_FILE = path.resolve(
+  __dirname,
+  '../../src/add-dummy-swift-file.rb'
+);
+
 const PACKAGES_TO_ADD_DEV = {
   'babel-plugin-module-resolver': '^5.0.0',
 };
@@ -54,6 +59,7 @@ export default async function generateExampleApp({
   projectName,
   arch,
   reactNativeVersion = 'latest',
+  swift = false,
 }: {
   type: 'expo' | 'native';
   dest: string;
@@ -61,6 +67,7 @@ export default async function generateExampleApp({
   projectName: string;
   arch: 'new' | 'mixed' | 'legacy';
   reactNativeVersion?: string;
+  swift?: boolean;
 }) {
   const directory = path.join(dest, 'example');
   const args =
@@ -84,6 +91,18 @@ export default async function generateExampleApp({
     cwd: dest,
     env: { ...process.env, npm_config_yes: 'true' },
   });
+
+  if (swift && process.platform === 'darwin') {
+    await spawn(
+      'ruby',
+      [
+        ADD_DUMMY_SWIFT_FILE,
+        path.join(directory, 'ios', `${projectName}Example.xcodeproj`),
+        `${projectName}Example`,
+      ],
+      {}
+    );
+  }
 
   // Remove unnecessary files and folders
   for (const file of FILES_TO_DELETE) {


### PR DESCRIPTION
### Summary

It seems that swift debugging in libraries doesn't really work unless the app itself has a swift file. See https://github.com/callstack/react-native-builder-bob/discussions/517

There is an empty `File.swift` in example-legacy template but it's not added to the project. This change executes a ruby script to include that file in the Xcode project.

Note that it requires working `ruby` install and `xcodeproj` gem available and only run on Mac. Which is reasonable as , ruby and xcodeproj are decencies of cocoa pods.

### Test plan

