### PR TITLE
fix: podspec file indentation

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.identifier %}.podspec
@@ -27,24 +27,24 @@ Pod::Spec.new do |s|
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else
-  s.dependency "React-Core"
+    s.dependency "React-Core"
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
 <% if (project.view) { -%>
-    s.dependency "React-RCTFabric"
+      s.dependency "React-RCTFabric"
 <% } -%>
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-   end
-  end    
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

After https://github.com/callstack/react-native-builder-bob/pull/358 identation become shifted which makes code hard to read and could lead to bugs. For example I was placing package dependencies inside `if/else` block, right after `s.dependency "React-Core"`

see 
| before | after |
|--------|--------|
| <img width="1624" alt="image" src="https://github.com/callstack/react-native-builder-bob/assets/1577804/65a6b479-3e76-4170-b874-b5635b6a5401"> | <img width="1624" alt="image" src="https://github.com/callstack/react-native-builder-bob/assets/1577804/5e3862e7-e6d9-48da-9efd-5c3e5f611749"> |



### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Purely aesthetic changes, so nothing to break
