### PR TITLE
Add abiFilters to the native template

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -18,6 +18,11 @@ buildscript {
   }
 }
 
+def reactNativeArchitectures() {
+  def value = project.getProperties().get("reactNativeArchitectures")
+  return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
@@ -75,6 +80,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
+        abiFilters (*reactNativeArchitectures())
       }
     }
 <% } -%>

--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 }
 
 def reactNativeArchitectures() {
-  def value = project.getProperties().get("reactNativeArchitectures")
+  def value = rootProject.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In the native template `abiFilters` is missing from `externalNativeBuild` block. This means that the library would be built for every available ABI when building the application, even if the application itself is being built for a specific one. This is not that problematic (besides taking more time) when using React Native aar, but when building RN from source the core `.so` files will be built for that specific ABI. In case the library depends on a `.so` file, it would fail at the linking stage due to missing `.so` for the remaining ABIs.

### Test plan
See
- https://github.com/Expensify/App/pull/40102
- https://github.com/Expensify/react-native-live-markdown/pull/284
- https://github.com/margelo/react-native-quick-sqlite/pull/41