### PR TITLE
feat(crnl): pass --template blank to create-expo-app

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -77,8 +77,14 @@ export default async function generateExampleApp({
           '--skip-install',
           '--npm',
         ]
-      : // `npx create-expo-app example --no-install`
-        ['create-expo-app@latest', directory, '--no-install'];
+      : // `npx create-expo-app example --no-install --template blank`
+        [
+          'create-expo-app@latest',
+          directory,
+          '--no-install',
+          '--template',
+          'blank',
+        ];
 
   await spawn('npx', args, {
     cwd: dest,


### PR DESCRIPTION
### Summary

With [Expo SDK 51](https://expo.dev/changelog/2024/05-07-sdk-51), [Expo has changed their default app template](https://expo.dev/changelog/2024/05-07-sdk-51#new-default-project-template-and-getting-started-flow). This PR passes the `--template blank` param to `create-expo-app` so we can use a bare template. This also fixes [some of the CI issues we've been having](https://github.com/callstack/react-native-builder-bob/actions/runs/9227626360/job/25389966834?pr=551)

### Test plan

1. Create a new library and select `Javascript` as the library language
2. Make sure the generated library's `example/package.json` doesn't include `expo-router` as a dependency (`expo-router` is a dependency that comes with the new default app template).
3. Run `yarn lint` and make sure it passes. 
