### PR TITLE
Uses the corresponding react-native init version

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -63,7 +63,7 @@ export default async function generateExampleApp({
     type === 'native'
       ? // `npx react-native init <projectName> --directory example --skip-install`
         [
-          'react-native@latest',
+          `react-native@${reactNativeVersion}`,
           'init',
           `${projectName}Example`,
           '--directory',


### PR DESCRIPTION
closes #580

### Summary

Uses the corresponding version of react-native init as specified by the "--version" flag. This allows the module to be used on RNW versions other than "latest" since latest isn't always compatible with every version and a new version may introduce breaking changes.  

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Actually wasn't able to test this module locally, the instructions failed for me :( but tested `npx --yes react-native@0.75.0-rc.2 init testcli --directory examples --version 0.75.0-rc.2 --skip-install --npm` to make sure it works as intended.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
