### PR TITLE
fix: devDependencies doesn't exist in rootPackageJson

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -802,6 +802,10 @@ async function create(_argv: yargs.Arguments<any>) {
       path.join(folder, 'package.json')
     );
 
+    if (!rootPackageJson.dependencies) {
+      rootPackageJson.dependencies = {};
+    }
+
     rootPackageJson.devDependencies.react =
       examplePackageJson.dependencies.react;
     rootPackageJson.devDependencies['react-native'] =

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -802,8 +802,8 @@ async function create(_argv: yargs.Arguments<any>) {
       path.join(folder, 'package.json')
     );
 
-    if (!rootPackageJson.dependencies) {
-      rootPackageJson.dependencies = {};
+    if (!rootPackageJson.devDependencies) {
+      rootPackageJson.devDependencies = {};
     }
 
     rootPackageJson.devDependencies.react =


### PR DESCRIPTION
i faced the following issue:

Cannot set properties of undefined (setting 'react') /Users/imokhles/.nvm/versions/node/v20.13.1/lib/node_modules/create-react-native-library/lib/index.js:558
    rootPackageJson.devDependencies.react = examplePackageJson.dependencies.react;
                                          ^

TypeError: Cannot set properties of undefined (setting 'react')
    at Object.create [as handler] (/Users/imokhles/.nvm/versions/node/v20.13.1/lib/node_modules/create-react-native-library/lib/index.js:558:43)