### PR TITLE
Fix init command in generateTestApp method to use new @react-native-community/template package

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -91,8 +91,8 @@ export default async function generateExampleApp({
     `${project.package}.example`,
     '--directory',
     directory,
-    '--version',
-    reactNativeVersion,
+    '--template',
+    '@react-native-community/template@next',
     '--skip-install',
     '--npm',
   ];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR edits the init command to use the new template at [@react-native-community/template](https://www.npmjs.com/package/@react-native-community/template). Currently, it is set to use the `next` version, as there is a big discrepancy between the nightly build versions available on the react-native package and new @react-native-community/template package. 

This [PR](https://github.com/facebook/react-native/commit/4e14c5eeab86a188663c2eddf301f753c317235b) adds a job that will publish a nightly build to the @react-native-community/template package every time a new react-native package is published. Once the react-native-windows repo is integrated up to the same date, we will revert the 'next' to 'reactNativeVersion'. This pending change is tracked in the following issue: https://github.com/microsoft/react-native-windows/issues/13446

### Test plan

1. Change the `create-react-native-library.cmd` line 3 to the following: 
`node "%~dp0\create-react-native-library" %* --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com/ --repo-url http://example.com/ --languages java-objc --type module-new --react-native-version 0.75.0-nightly-20240618-5df5ed1a8 --example vanilla testcli`
2. Run `yarn watch`
3. Run `packages/create-react-native-library/bin/create-react-native-library`
