### PR TITLE
fix: hide select example question when creating local library

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -471,7 +471,10 @@ async function create(_argv: yargs.Arguments<any>) {
         });
       },
     },
-    {
+  ];
+
+  if (!local) {
+    questions.push({
       type: 'select',
       name: 'example',
       message: 'What type of example app do you want to create?',
@@ -486,8 +489,8 @@ async function create(_argv: yargs.Arguments<any>) {
           return true;
         });
       },
-    },
-  ];
+    });
+  }
 
   const validate = (answers: Answers) => {
     for (const [key, value] of Object.entries(answers)) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

A regression introduced in https://github.com/callstack/react-native-builder-bob/pull/572. 

CRNL shouldn't ask for example type in local library scenario.

### Test plan

1. Run `create-react-native-library` under a React Native project.
2. Example project shouldn't be included in the local library.