### PR TITLE
fix: add correct script on Android

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -163,7 +163,7 @@ export default async function generateExampleApp({
     const iosBuild = [
       'npm run mkdist',
       'react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist',
-      SCRIPTS_TO_ADD['build:android'],
+      SCRIPTS_TO_ADD['build:ios'],
     ].join(' && ');
 
     Object.assign(scripts, {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a regression where `build-android` contained a script for building iOS app. 

### Test plan

`build:android` should contain script for building Android app.