### PR TITLE
fix: always create package.json with type regardless of esm option

### DIFF
--- a/docs/pages/esm.md
+++ b/docs/pages/esm.md
@@ -16,12 +16,9 @@ You can verify whether ESM support is enabled by checking the configuration for 
 }
 ```
 
-The `"esm": true` option enables ESM-compatible output. Here's what it does:
+The `"esm": true` option enables ESM-compatible output by adding the `.js` extension to the import statements in the generated files.
 
-- It adds the `.js` extension to the import statements in the generated files.
-- It creates a `package.json` file in the output directory with the content: `{ "type": "module" }`
-
-In addition, it's necessary to specify `"moduleResolution": "Bundler"` in your `tsconfig.json` file:
+It's recommended to specify `"moduleResolution": "Bundler"` in your `tsconfig.json` file as well:
 
 ```json
 {

--- a/packages/react-native-builder-bob/src/utils/compile.ts
+++ b/packages/react-native-builder-bob/src/utils/compile.ts
@@ -68,12 +68,9 @@ export default async function compile({
   }
 
   await fs.mkdirp(output);
-
-  if (esm) {
-    await fs.writeJSON(path.join(output, 'package.json'), {
-      type: modules === 'commonjs' ? 'commonjs' : 'module',
-    });
-  }
+  await fs.writeJSON(path.join(output, 'package.json'), {
+    type: modules === 'commonjs' ? 'commonjs' : 'module',
+  });
 
   await Promise.all(
     files.map(async (filepath) => {


### PR DESCRIPTION
This will provide more flexibilty to library authors such as specifying `type: module` in their project's `package.json` without breaking the commonjs output for the published code.