### PR TITLE
Update CLI to use `@react-native-community/cli init` instead of `react-native init`

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -81,9 +81,9 @@ export default async function generateExampleApp({
     'android',
   ];
 
-  // `npx react-native init <projectName> --directory example --skip-install`
+  // `npx @react-native-community/cli init <projectName> --directory example --skip-install`
   const vanillaArgs = [
-    `react-native@${reactNativeVersion}`,
+    `@react-native-community/cli`,
     'init',
     `${project.name}Example`,
     '--package-name',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When trying to build a vanilla library with a version of React Native 0.76 (e.g 0.76.0-nightly-20240701-9f6cb21ed), the script fails with the following error: 
```
ℹ Using react-native@0.76.0-nightly-20240701-9f6cb21ed for the example
⠹ Generating example app

⚠️ The `init` command is deprecated.

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started
C:\new-account-repos\react-native-builder-bob\packages\create-react-native-library\lib\utils\spawn.js:27
        reject(new Error(stderr.trim()));
```

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Allows creating a vanilla library with CRNL on 0.76 versions of react-native. This issue was hit in the RNW repo where we are trying to [integrate](https://github.com/microsoft/react-native-windows/pull/13508) 0.76.0-nightly-20240701-9f6cb21ed.

### Test Plan
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

1. Change the create-react-native-library.cmd line 3 to the following:
`node "%~dp0\create-react-native-library" %* --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com/ --repo-url http://example.com/ --languages kotlin-objc --type module-new --react-native-version 0.76.0-nightly-20240701-9f6cb21ed --example vanilla testcli`
2. Run `yarn watch`
2. Run `packages/create-react-native-library/bin/create-react-native-library`
