### PR TITLE
fix: ensure assets are registered correctly

### DIFF
--- a/packages/react-native-builder-bob/metro-config.js
+++ b/packages/react-native-builder-bob/metro-config.js
@@ -17,7 +17,12 @@ const exclusionList = require('metro-config/src/defaults/exclusionList');
  * @returns {import('metro-config').MetroConfig} Metro configuration
  */
 const getConfig = (defaultConfig, { root, pkg, project }) => {
-  const modules = Object.keys({ ...pkg.peerDependencies });
+  const modules = [
+    // AssetsRegistry is used internally by React Native to handle asset imports
+    // This needs to be a singleton so all assets are registered to a single registry
+    '@react-native/assets-registry',
+    ...Object.keys({ ...pkg.peerDependencies }),
+  ];
 
   /**
    * Metro configuration


### PR DESCRIPTION
react-native uses a asset registry package to register assets. seems the library and the example app are using different copies of this package, presumably because Expo CLI embeds `@react-native/assets-registry` verbatim in the code during transform. this causes the library not to use the same copy of the package as `react-native`. this results in broken assets in the app.

with this change we're ensuring that we always load a single version of the package to ensure assets work.

closes #607