### PR TITLE
fix: creating library with react-native-test-app example

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -790,7 +790,7 @@ async function create(_argv: yargs.Arguments<any>) {
         examplePackageJson.dependencies['react-native'];
     }
 
-    if (arch !== 'legacy') {
+    if (arch !== 'legacy' && example === 'vanilla') {
       addCodegenBuildScript(folder, options.project.name);
     }
   }

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -202,8 +202,12 @@
     },
     "android": {
       "javaPackageName": "com.<%- project.package %>"
+    <% if (example === 'vanilla') { -%>
     },
     "includesGeneratedCode": true
+    <% } else { -%>    
+    }
+    <% } -%>
 <% } -%>
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Conditionally add codegen-releated stuff added recently to unblocks the command. 

### Test plan

1. `create-react-native-library`
2. Choose test app as an example
3. `example/` apps should build.
