### PR TITLE
fix: typo in cmakeListsPath for turbo native modules

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -657,6 +657,7 @@ async function create(_argv: yargs.Arguments<any>) {
     repo: repoUrl,
     example,
     year: new Date().getFullYear(),
+    local,
   };
 
   const copyDir = async (source: string, dest: string) => {

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -657,7 +657,6 @@ async function create(_argv: yargs.Arguments<any>) {
     repo: repoUrl,
     example,
     year: new Date().getFullYear(),
-    local,
   };
 
   const copyDir = async (source: string, dest: string) => {

--- a/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
@@ -5,7 +5,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
@@ -6,9 +6,9 @@ module.exports = {
     platforms: {
       android: {
         <%_ if (local) { -%>
-          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
         <%_ } else { -%>
-          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'generated/jni/CMakeLists.txt',
         <%_ } -%>
       },
     },

--- a/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
@@ -5,7 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ if (local) { -%>
+          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ } else { -%>
+          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <%_ if (local) { -%>
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <%_ } else { -%>
+        <% if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <%_ } -%>
+        <% } else { -%>
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <% } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-mixed/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <% if (example === 'vanilla') { -%>
+        <%_ if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <% } else { -%>
+        <%_ } else { -%>
         cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <% } -%>
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-new/react-native.config.js
@@ -5,7 +5,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-new/react-native.config.js
@@ -6,9 +6,9 @@ module.exports = {
     platforms: {
       android: {
         <%_ if (local) { -%>
-          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
         <%_ } else { -%>
-          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'generated/jni/CMakeLists.txt',
         <%_ } -%>
       },
     },

--- a/packages/create-react-native-library/templates/native-library-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-new/react-native.config.js
@@ -5,7 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ if (local) { -%>
+          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ } else { -%>
+          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-new/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <%_ if (local) { -%>
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <%_ } else { -%>
+        <% if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <%_ } -%>
+        <% } else { -%>
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <% } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-library-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-library-new/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <% if (example === 'vanilla') { -%>
+        <%_ if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <% } else { -%>
+        <%_ } else { -%>
         cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <% } -%>
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
@@ -5,7 +5,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
@@ -6,9 +6,9 @@ module.exports = {
     platforms: {
       android: {
         <%_ if (local) { -%>
-          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
         <%_ } else { -%>
-          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'generated/jni/CMakeLists.txt',
         <%_ } -%>
       },
     },

--- a/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
@@ -5,7 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ if (local) { -%>
+          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ } else { -%>
+          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <%_ if (local) { -%>
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <%_ } else { -%>
+        <% if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <%_ } -%>
+        <% } else { -%>
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <% } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-mixed/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <% if (example === 'vanilla') { -%>
+        <%_ if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <% } else { -%>
+        <%_ } else { -%>
         cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <% } -%>
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-new/react-native.config.js
@@ -5,7 +5,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-new/react-native.config.js
@@ -6,9 +6,9 @@ module.exports = {
     platforms: {
       android: {
         <%_ if (local) { -%>
-          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
         <%_ } else { -%>
-          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cmakeListsPath: 'generated/jni/CMakeLists.txt',
         <%_ } -%>
       },
     },

--- a/packages/create-react-native-library/templates/native-view-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-new/react-native.config.js
@@ -5,7 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ if (local) { -%>
+          cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <%_ } else { -%>
+          cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        <%_ } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-new/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <%_ if (local) { -%>
-        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <%_ } else { -%>
+        <% if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <%_ } -%>
+        <% } else { -%>
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+        <% } -%>
       },
     },
   },

--- a/packages/create-react-native-library/templates/native-view-new/react-native.config.js
+++ b/packages/create-react-native-library/templates/native-view-new/react-native.config.js
@@ -5,11 +5,11 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        <% if (example === 'vanilla') { -%>
+        <%_ if (example === 'vanilla') { -%>
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
-        <% } else { -%>
+        <%_ } else { -%>
         cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
-        <% } -%>
+        <%_ } -%>
       },
     },
   },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

It fixes #627, as we were having the same issue in our react native project.
When opting in Turbo Native Modules or Fabric Views, `cmakeListPath` in generated `react-native.config.js` was not consistent with the hierarchy generated by CodeGen.
This fix corrects the path as stated by document.

If my fix isn't correct, feel free to correct me.
Thank you.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Select 'Turbo module - requires new arch (experimental)' to create Turbo native module and include it into the project
- Build for android with `npx react-native run-android` to validate the fix was correct.