### PR TITLE
fix: single answer questions dont get stored with metadata

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -358,7 +358,7 @@ async function create(_argv: yargs.Arguments<any>) {
 
   const questions: (Omit<PromptObject<keyof Answers>, 'validate' | 'name'> & {
     validate?: (value: string) => boolean | string;
-    name: string;
+    name: keyof Answers;
   })[] = [
     {
       type: 'text',
@@ -521,6 +521,8 @@ async function create(_argv: yargs.Arguments<any>) {
   // Validate arguments passed to the CLI
   validate(argv);
 
+  const singleChoiceAnswers: Partial<Answers> = {};
+
   const answers = {
     ...argv,
     local,
@@ -540,6 +542,8 @@ async function create(_argv: yargs.Arguments<any>) {
             Array.isArray(question.choices) &&
             question.choices.length === 1
           ) {
+            const onlyChoice = question.choices[0]!;
+            singleChoiceAnswers[question.name] = onlyChoice.value;
             return false;
           }
 
@@ -554,8 +558,9 @@ async function create(_argv: yargs.Arguments<any>) {
               ...question,
               type: (prev, values, prompt) => {
                 const result = choices(prev, { ...argv, ...values }, prompt);
-
                 if (result && result.length === 1) {
+                  const onlyChoice = result[0]!;
+                  singleChoiceAnswers[question.name] = onlyChoice.value;
                   return null;
                 }
 
@@ -567,6 +572,7 @@ async function create(_argv: yargs.Arguments<any>) {
           return question;
         })
     )),
+    ...singleChoiceAnswers,
   } as Answers;
 
   validate(answers);


### PR DESCRIPTION
### Summary

If a question has a single answer on `create-react-native-library`, we skip that question. However, due to a bug, single answer questions weren't making it to the metadata stored with new project. This PR fixes that

### Test plan

A good example is the `Fabric view with backward compat`. This option had a single language setting `kotlin and objective c`. To test this PR, you can create a new project with these options and make sure the language is getting stored properly.