### PR TITLE
fix: make sure react-native.config.json is shipped with each library Fixes #647

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -24,6 +24,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "react-native.config.json",
     "!ios/build",
     "!android/build",
     "!android/gradle",


### PR DESCRIPTION
### Summary

With the new introduction of https://github.com/callstack/react-native-builder-bob/commit/a90142f471d3c39bd5f9a98c17a64ff23be9b8af#diff-4282562f42ade49c2eb46dee36bcbb7987322efec211330f48387a10e5514678R206 that adds `includeGeneratedCode`, `react-native.config.js` needs to be shipped with the NPM module to signal what directory to use.

### Test plan

Tested `react-native-vector-icons` where I discovered this issue against my project.