### PR TITLE
feat: add clean option for cleaning build directory

### DIFF
--- a/packages/react-native-builder-bob/src/index.ts
+++ b/packages/react-native-builder-bob/src/index.ts
@@ -13,13 +13,18 @@ import buildTypescript from './targets/typescript';
 import buildCodegen from './targets/codegen';
 import type { Options, Report, Target } from './types';
 
-type ArgName = 'target';
+type ArgName = 'target' | 'clean';
 
 const args = {
   target: {
     type: 'string',
     description: 'The target to build',
-    choices: ['commonjs', 'module', 'typescript', 'codegen'] satisfies Target[],
+    choices: ['commonjs', 'module', 'typescript', 'codegen'] satisfies Target[], // Keep existing choices
+  },
+  clean: {
+    type: 'boolean',
+    description: 'Clean the build directory before building',
+    default: true,
   },
 } satisfies Record<ArgName, yargs.Options>;
 
@@ -507,6 +512,7 @@ yargs
 
     if (argv.target != null) {
       buildTarget(
+        argv.clean,
         argv.target,
         report,
         source as string,
@@ -516,6 +522,7 @@ yargs
     } else {
       for (const target of options.targets!) {
         buildTarget(
+          argv.clean,
           target,
           report,
           source as string,
@@ -530,6 +537,7 @@ yargs
   .strict().argv;
 
 async function buildTarget(
+  clean: boolean,
   target: Exclude<Options['targets'], undefined>[number],
   report: Report,
   source: string,
@@ -544,6 +552,7 @@ async function buildTarget(
   switch (targetName) {
     case 'commonjs':
       await buildCommonJS({
+        clean,
         root,
         source: path.resolve(root, source),
         output: path.resolve(root, output, 'commonjs'),
@@ -554,6 +563,7 @@ async function buildTarget(
       break;
     case 'module':
       await buildModule({
+        clean,
         root,
         source: path.resolve(root, source),
         output: path.resolve(root, output, 'module'),
@@ -564,6 +574,7 @@ async function buildTarget(
       break;
     case 'typescript':
       await buildTypescript({
+        clean,
         root,
         source: path.resolve(root, source),
         output: path.resolve(root, output, 'typescript'),
@@ -573,6 +584,7 @@ async function buildTarget(
       break;
     case 'codegen':
       await buildCodegen({
+        clean,
         root,
         source: path.resolve(root, source),
         output: path.resolve(root, output, 'typescript'),

--- a/packages/react-native-builder-bob/src/targets/codegen.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen.ts
@@ -6,14 +6,16 @@ import fs from 'fs-extra';
 import path from 'path';
 import del from 'del';
 
-type Options = Input;
+type Options = Input & {
+  clean: boolean;
+};
 
-export default async function build({ root, report }: Options) {
+export default async function build({ clean, root, report }: Options) {
   const packageJsonPath = path.resolve(root, 'package.json');
   const packageJson = await fs.readJson(packageJsonPath);
 
   const codegenIosPath = packageJson.codegenConfig?.outputDir?.ios;
-  if (codegenIosPath != null) {
+  if (codegenIosPath != null && clean) {
     report.info(
       `Cleaning up previous iOS codegen native code at ${kleur.blue(
         path.relative(root, codegenIosPath)
@@ -23,7 +25,7 @@ export default async function build({ root, report }: Options) {
   }
 
   const codegenAndroidPath = packageJson.codegenConfig?.outputDir?.android;
-  if (codegenAndroidPath != null) {
+  if (codegenAndroidPath != null && clean) {
     report.info(
       `Cleaning up previous Android codegen native code at ${kleur.blue(
         path.relative(root, codegenAndroidPath)

--- a/packages/react-native-builder-bob/src/targets/commonjs.ts
+++ b/packages/react-native-builder-bob/src/targets/commonjs.ts
@@ -12,10 +12,12 @@ type Options = Input & {
     sourceMaps?: boolean;
     copyFlow?: boolean;
   };
+  clean: boolean;
   exclude: string;
 };
 
 export default async function build({
+  clean,
   root,
   source,
   output,
@@ -23,11 +25,13 @@ export default async function build({
   options,
   report,
 }: Options) {
-  report.info(
-    `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
-  );
+  if (clean) {
+    report.info(
+      `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
+    );
 
-  await del([output]);
+    await del([output]);
+  }
 
   await compile({
     ...options,

--- a/packages/react-native-builder-bob/src/targets/module.ts
+++ b/packages/react-native-builder-bob/src/targets/module.ts
@@ -12,10 +12,12 @@ type Options = Input & {
     sourceMaps?: boolean;
     copyFlow?: boolean;
   };
+  clean: boolean;
   exclude: string;
 };
 
 export default async function build({
+  clean,
   root,
   source,
   output,
@@ -23,11 +25,13 @@ export default async function build({
   options,
   report,
 }: Options) {
-  report.info(
-    `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
-  );
+  if (clean) {
+    report.info(
+      `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
+    );
 
-  await del([output]);
+    await del([output]);
+  }
 
   await compile({
     ...options,

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -14,6 +14,7 @@ type Options = Input & {
     project?: string;
     tsc?: string;
   };
+  clean: boolean;
 };
 
 type Field = {
@@ -24,17 +25,20 @@ type Field = {
 };
 
 export default async function build({
-  source,
+  clean,
   root,
+  source,
   output,
   report,
   options,
 }: Options) {
-  report.info(
-    `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
-  );
+  if (clean) {
+    report.info(
+      `Cleaning up previous build at ${kleur.blue(path.relative(root, output))}`
+    );
 
-  await del([output]);
+    await del([output]);
+  }
 
   report.info(`Generating type definitions with ${kleur.blue('tsc')}`);
 


### PR DESCRIPTION
### Summary

Added a 'clean' flag to the build command with a default value of `true`. 
This flag allows for optional cleaning of the build directory before executing the build process. 
By default, the build directory will be cleaned unless explicitly set otherwise.

When using `nodemon`, the default behavior of deleting the output directory may cause issues with Metro Bundler. To avoid this, users can disable the `clean` flag by passing `--clean=false`.

### Test plan

1. Run `build` (without any flags).
   - Ensure the build directory is cleaned by default.
2. Run `build --clean false`.
   - Ensure the build proceeds without cleaning the build directory.
3. Run `build --clean`.
   - Ensure the build directory is cleaned before building.
