### PR TITLE
feat: make the vanilla example app the first option

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -145,14 +145,14 @@ const LANGUAGE_CHOICES: {
 
 const EXAMPLE_CHOICES = [
   {
-    title: 'Test app',
-    value: 'test-app',
-    description: "app's native code is abstracted away",
-  },
-  {
     title: 'Vanilla',
     value: 'vanilla',
     description: "provides access to app's native code",
+  },
+  {
+    title: 'Test app',
+    value: 'test-app',
+    description: "app's native code is abstracted away",
   },
   {
     title: 'Expo',


### PR DESCRIPTION
### Summary

This makes the vanilla example app the first option when the CLI asks for the type of the example app.
![Screenshot 2024-10-18 at 18 12 00](https://github.com/user-attachments/assets/63943479-cab2-4a54-b8e7-6d5a6355799d)

We were seeing some RNTA specific bugs such as #639

With that being said, this is in no way an attempt to fix the bugs that are caused by create-react-native-library when we integrate with the React Native Testing App. Such bugs should still be fixed by the team.

### Test plan

1. Run creact-react-native-library
2. Pick a native library template
3. Make sure when the example type is asked, vanilla example is the first option.
