### PR TITLE
fix: unknown option npm when generating a vanilla example app

### DIFF
--- a/packages/create-react-native-library/src/utils/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/utils/generateExampleApp.ts
@@ -93,7 +93,8 @@ export default async function generateExampleApp({
     '--version',
     reactNativeVersion,
     '--skip-install',
-    '--npm',
+    '--pm',
+    'npm',
   ];
 
   // `npx create-expo-app example --no-install --template blank`


### PR DESCRIPTION
### Summary

Fixes #663 

### Test plan

1. Generate a new library with the vanilla example app
2. Make sure you don't get an exception
