### PR TITLE
fix: vanilla example codegen fails

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -790,8 +790,23 @@ async function create(_argv: yargs.Arguments<any>) {
         examplePackageJson.dependencies['react-native'];
     }
 
-    if (arch !== 'legacy' && example === 'vanilla') {
-      addCodegenBuildScript(folder, options.project.name);
+    if (example === 'vanilla') {
+      // React Native doesn't provide the community CLI as a dependency.
+      // We have to get read the version from the example app and put to the root package json
+      const exampleCommunityCLIVersion =
+        examplePackageJson.devDependencies['@react-native-community/cli'];
+      console.assert(
+        exampleCommunityCLIVersion !== undefined,
+        "The generated example app doesn't have community CLI installed"
+      );
+
+      rootPackageJson.devDependencies = rootPackageJson.devDependencies || {};
+      rootPackageJson.devDependencies['@react-native-community/cli'] =
+        exampleCommunityCLIVersion;
+
+      if (arch !== 'legacy') {
+        addCodegenBuildScript(folder, options.project.name);
+      }
     }
   }
 

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -5,6 +5,7 @@ import dedent from 'dedent';
 import kleur from 'kleur';
 import yargs from 'yargs';
 import ora from 'ora';
+import assert from 'node:assert';
 import validateNpmPackage from 'validate-npm-package-name';
 import githubUsername from 'github-username';
 import prompts, { type PromptObject } from './utils/prompts';
@@ -795,7 +796,7 @@ async function create(_argv: yargs.Arguments<any>) {
       // We have to get read the version from the example app and put to the root package json
       const exampleCommunityCLIVersion =
         examplePackageJson.devDependencies['@react-native-community/cli'];
-      console.assert(
+      assert(
         exampleCommunityCLIVersion !== undefined,
         "The generated example app doesn't have community CLI installed"
       );

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -72,6 +72,9 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
+<% if (example === 'vanilla') { -%>
+    "@react-native-community/cli": "15.0.0-alpha.2",
+<% } -%>
     "@react-native/eslint-config": "^0.73.1",
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/jest": "^29.5.5",

--- a/packages/react-native-builder-bob/src/targets/codegen.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen.ts
@@ -33,7 +33,7 @@ export default async function build({ root, report }: Options) {
   }
 
   try {
-    await spawn('npx', ['react-native', 'codegen'], {
+    await spawn('npx', ['@react-native-community/cli', 'codegen'], {
       stdio: 'ignore',
     });
 


### PR DESCRIPTION
### Summary

Fixes #662

### Test plan

1. Create a vanilla example library
2. Make sure `@react-native-community/cli` is added as a dependency
3. make sure `yarn prepare` doesn't throw