### PR TITLE
feat: add `--example none`, `--replace-directory`, and `--skip-git` options

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -160,6 +160,11 @@ const EXAMPLE_CHOICES = [
     value: 'expo',
     description: 'managed expo project with web support',
   },
+  {
+    title: 'None',
+    value: 'none',
+    description: 'no example app will be created',
+  },
 ] as const;
 
 const NEWARCH_DESCRIPTION = 'requires new arch (experimental)';
@@ -933,12 +938,16 @@ async function create(_argv: yargs.Arguments<any>) {
     );
   } else {
     const platforms = {
-      ios: { name: 'iOS', color: 'cyan' },
-      android: { name: 'Android', color: 'green' },
+      ...(example === 'none'
+        ? {}
+        : {
+            ios: { name: 'iOS', colorize: kleur.cyan },
+            android: { name: 'Android', colorize: kleur.green },
+          }),
       ...(example === 'expo'
-        ? ({ web: { name: 'Web', color: 'blue' } } as const)
+        ? { web: { name: 'Web', colorize: kleur.blue } }
         : null),
-    } as const;
+    };
 
     console.log(
       dedent(`
@@ -949,8 +958,8 @@ async function create(_argv: yargs.Arguments<any>) {
         ${kleur.gray('$')} yarn
       ${Object.entries(platforms)
         .map(
-          ([script, { name, color }]) => `
-      ${kleur[color](`Run the example app on ${kleur.bold(name)}`)}${kleur.gray(
+          ([script, { name, colorize }]) => `
+      ${colorize(`Run the example app on ${kleur.bold(name)}`)}${kleur.gray(
         ':'
       )}
 

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -81,6 +81,7 @@ type ArgName =
   | 'languages'
   | 'type'
   | 'local'
+  | 'skip-git'
   | 'replace-directory'
   | 'example'
   | 'react-native-version';
@@ -258,6 +259,10 @@ const args: Record<ArgName, yargs.Options> = {
     description: 'Type of the example app to create',
     type: 'string',
     choices: EXAMPLE_CHOICES.map(({ value }) => value),
+  },
+  'skip-git': {
+    description: 'Skip git actions',
+    type: 'boolean',
   },
   'replace-directory': {
     description: 'Replaces the directory if it already exists.',
@@ -858,6 +863,7 @@ async function create(_argv: yargs.Arguments<any>) {
 
     try {
       isInGitRepo =
+        !argv.skipGit &&
         (await spawn('git', ['rev-parse', '--is-inside-work-tree'])) === 'true';
     } catch (e) {
       // Ignore error

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -81,6 +81,7 @@ type ArgName =
   | 'languages'
   | 'type'
   | 'local'
+  | 'replace-directory'
   | 'example'
   | 'react-native-version';
 
@@ -258,6 +259,10 @@ const args: Record<ArgName, yargs.Options> = {
     type: 'string',
     choices: EXAMPLE_CHOICES.map(({ value }) => value),
   },
+  'replace-directory': {
+    description: 'Replaces the directory if it already exists.',
+    type: 'boolean',
+  },
 };
 
 // FIXME: fix the type
@@ -324,7 +329,7 @@ async function create(_argv: yargs.Arguments<any>) {
     folder = path.join(process.cwd(), answers.folder);
   }
 
-  if (await fs.pathExists(folder)) {
+  if (!argv.replaceDirectory && (await fs.pathExists(folder))) {
     console.log(
       `A folder already exists at ${kleur.blue(
         folder


### PR DESCRIPTION
Hello! First, thank you for the work on Bob and create-react-native-library.

I've made a few modifications on `create-react-native-library` to support a tooling ([qdk](https://github.com/gabrielmoreira/qdk/)) setup I'm working on.

### Summary of Changes:
1. **Added `--example none` option**: Allows creating libraries without an example app.
2. **Added `--replace-directory` option**: Enables overwriting the template in an existing directory, using a similar option name as in the React Native CLI.
3. **Added `--skip-git` option**: Prevents any git commands from running during template creation, also following a naming convention similar to the React Native CLI.

### Context:
In my tool ([qdk](https://github.com/gabrielmoreira/qdk/blob/main/templates/monorepo/.qdk/components/ReactNativeLibProject.ts#L238)), I have templates for different project structures, and one of these templates uses `create-react-native-library` to set up a React Native library project. The goal is to generate only the library code, without an example app, without interfering with the project git, and with the flexibility to overwrite an existing directory if it already contains some files.

Thanks for considering these additions!

*P.S.*: By the way, the options added here follow a similar naming convention to `npx @react-native-community/cli init` options, for consistency.

I also considered contributing an optional parameter to fix the version of `npx @react-native-community/cli@<<VERSION>> init`, but for my case, not creating the example app was more beneficial. The vanilla example was giving me errors during generation, even though it was working a few days ago. Fixing the version of create-react-library wasn’t enough.

Additionally, I thought about adding an option to specify the package manager instead of trying to detect it. However, this would require more testing with various package managers, so I decided to hold off on that for now.