### PR TITLE
chore: bump release-it and release-it conventional changelog versions

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -76,7 +76,7 @@
     "@react-native-community/cli": "15.0.0-alpha.2",
 <% } -%>
     "@react-native/eslint-config": "^0.73.1",
-    "@release-it/conventional-changelog": "^5.0.0",
+    "@release-it/conventional-changelog": "^9.0.2",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
     "commitlint": "^17.0.2",
@@ -89,7 +89,7 @@
     "react": "17.0.2",
     "react-native": "0.73.0",
     "react-native-builder-bob": "^<%- bob.version %>",
-    "release-it": "^15.0.0",
+    "release-it": "^17.10.0",
 <% if (example !== 'expo') { -%>
     "turbo": "^1.10.7",
 <% } -%>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Hey folks, Dependabot is flagging a vulnerability in the vm2 package from this exploit: https://gist.github.com/leesh3288/f693061e6523c97274ad5298eb2c74e9

I think React Native Builder Bob carries that forward through packages: `release-it` -> `proxy-agent` -> `pac-proxy-agent` -> `pac-resolver` -> `degenerator` -> `vm2`

From what I can tell, the vulnerability is basically unused code for any consumer of Builder Bob, but the included versions of `release-it` and `@release-it/conventional-changelog` are also pretty old. Bumping those versions should clean up some Dependabot noise for people who use this tool, and keep everyone up to date.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Hard to actually test since it's a dev dependency that different users will configure differently, but I did some investigation in all the breaking changes and I think they are quite minor.

For `release-it`, this would jump across a breaking change in v16 which just [removes support for Node v14](https://github.com/release-it/release-it/blob/main/CHANGELOG.md#v16-2023-07-05), and a breaking change in v17 which [removes support for Node v16](https://github.com/release-it/release-it/blob/main/CHANGELOG.md#v16-2023-07-05). Both of those are [EOL](https://nodejs.org/en/blog/announcements/nodejs16-eol)

The plugin, `@release-it/conventional-changelog` would jump a few breaking versions, but those changes also seem minor:

1. 6.0.0 doesn't seem to do much other than [update some of its own dependencies](https://github.com/release-it/conventional-changelog/releases/tag/6.0.0) and change internal tooling for its own GH actions
2. 7.0.0 is just a break to [support release-it 16](https://github.com/release-it/conventional-changelog/releases/tag/7.0.0) and its node deprecation
3. 8.0.0 [drops support for Node v16](https://github.com/release-it/conventional-changelog/releases/tag/8.0.0)
4. 9.0.0 [only updates dependencies and adds a gitignore](https://github.com/release-it/conventional-changelog/releases/tag/9.0.0).

Overall seems like a pretty smooth upgrade path.