### PR TITLE
fix: type issue in crnl index

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -150,21 +150,24 @@ const EXAMPLE_CHOICES = (
       title: 'Vanilla',
       value: 'vanilla',
       description: "provides access to app's native code",
+      disabled: false,
     },
-    // The test app is disabled for now until proper
-    // Codegen spec shipping is implemented
-    process.env.CRNL_ENABLE_TEST_APP && {
+    {
       title: 'Test app',
       value: 'test-app',
       description: "app's native code is abstracted away",
+      // The test app is disabled for now until proper
+      // Codegen spec shipping is implemented
+      disabled: !process.env.CRNL_ENABLE_TEST_APP,
     },
     {
       title: 'Expo',
       value: 'expo',
       description: 'managed expo project with web support',
+      disabled: false,
     },
   ] as const
-).filter(Boolean);
+).filter((choice) => !choice.disabled);
 
 const NEWARCH_DESCRIPTION = 'requires new arch (experimental)';
 const BACKCOMPAT_DESCRIPTION = 'supports new arch (experimental)';


### PR DESCRIPTION
### Summary

We had a type issue in the `create-react-native-library` index due to using `as const` with a conditional array. I merged this code without checking the CI since it was already failing.

### Test plan

1. Make sure `yarn typecheck` passes.
