### PR TITLE
fix: every created example app is testing app

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -588,7 +588,7 @@ async function create(_argv: yargs.Arguments<any>) {
     repoUrl,
     type = 'module-mixed',
     languages = type === 'library' ? 'js' : 'kotlin-objc',
-    example = local ? 'none' : type === 'library' ? 'expo' : 'test-app',
+    example = local ? 'none' : type === 'library' ? 'expo' : 'vanilla',
     reactNativeVersion,
   } = answers;
 


### PR DESCRIPTION
### Summary

We aren't properly injecting the single-choice questions into our answers yet, and as a result the default example app was testing app. Addressed that problem

### Test plan

1. Create a new library
2. Make sure the example app is a vanilla testing app