### PR TITLE
fix: expo app doesn't have index.js

### DIFF
--- a/packages/create-react-native-library/templates/expo-library/example/App.js
+++ b/packages/create-react-native-library/templates/expo-library/example/App.js
@@ -1,1 +1,0 @@
-export { default } from './src/App';

--- a/packages/create-react-native-library/templates/expo-library/example/index.js
+++ b/packages/create-react-native-library/templates/expo-library/example/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './src/App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);


### PR DESCRIPTION
### Summary

Generated expo example apps were missing the `index.js` file.
Fixes #682 

### Test plan

1. Create a JS library
2. Run the example app and make sure it displays correctly
