### PR TITLE
fix: spawn CLI directly without using Node

### DIFF
--- a/packages/react-native-builder-bob/src/utils/runRNCCli.ts
+++ b/packages/react-native-builder-bob/src/utils/runRNCCli.ts
@@ -27,7 +27,7 @@ export async function runRNCCli(
     rncCliBinaryName
   );
 
-  return await spawn(RNC_CLI_BINARY_PATH, [...args], options);
+  return await spawn(RNC_CLI_BINARY_PATH, args, options);
 }
 
 async function getCliBinaryName(): Promise<string> {

--- a/packages/react-native-builder-bob/src/utils/runRNCCli.ts
+++ b/packages/react-native-builder-bob/src/utils/runRNCCli.ts
@@ -4,10 +4,7 @@ import path from 'node:path';
 import fs from 'fs-extra';
 import assert from 'node:assert';
 
-// This is a special case for calling bob from the XCode scripts
-// XCode scripts don't have the node binary properly set
-// We expose an env value for node instead.
-const NODE_BINARY = process.env['NODE_BINARY'] || 'node';
+const NODE_BINARY = 'node';
 
 /**
  * Runs the React Native Community CLI with the specified arguments

--- a/packages/react-native-builder-bob/src/utils/runRNCCli.ts
+++ b/packages/react-native-builder-bob/src/utils/runRNCCli.ts
@@ -1,8 +1,8 @@
-import { type SpawnOptions } from 'node:child_process';
-import { spawn } from './spawn';
+import assert from 'node:assert';
+import type { SpawnOptions } from 'node:child_process';
 import path from 'node:path';
 import fs from 'fs-extra';
-import assert from 'node:assert';
+import { spawn } from './spawn';
 
 // This is a special case for calling bob from the XCode scripts
 // XCode scripts don't have the node binary properly set
@@ -27,7 +27,7 @@ export async function runRNCCli(
     rncCliBinaryName
   );
 
-  return await spawn(NODE_BINARY, [RNC_CLI_BINARY_PATH, ...args], options);
+  return await spawn(RNC_CLI_BINARY_PATH, [...args], options);
 }
 
 async function getCliBinaryName(): Promise<string> {

--- a/packages/react-native-builder-bob/src/utils/runRNCCli.ts
+++ b/packages/react-native-builder-bob/src/utils/runRNCCli.ts
@@ -1,8 +1,8 @@
-import assert from 'node:assert';
-import type { SpawnOptions } from 'node:child_process';
+import { type SpawnOptions } from 'node:child_process';
+import { spawn } from './spawn';
 import path from 'node:path';
 import fs from 'fs-extra';
-import { spawn } from './spawn';
+import assert from 'node:assert';
 
 // This is a special case for calling bob from the XCode scripts
 // XCode scripts don't have the node binary properly set


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
![image](https://github.com/user-attachments/assets/2880ad03-3d96-4056-bbdf-299c34aba724)
The default is set to `yarn`, but an error occurs when using `pnpm` to run `bob build`.

The error arises because the CLI is spawned via Node. Since the CLI in `.bin` is designed to run with Node by default, it should spawn correctly even without explicitly prepending node.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

> The changes work correctly even when tested with Yarn.

1. Create a repository using the command:
```sh
> npx create-react-native-library@latest rn-lib
```
3. Remove the `packageManager` field from the `package.json`.
4. Run `pnpm install`
* as-is
5. An error occurs.
* to-be
5. Success.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
