### PR TITLE
fix: use npx to call rnccli

### DIFF
--- a/packages/react-native-builder-bob/src/utils/runRNCCli.ts
+++ b/packages/react-native-builder-bob/src/utils/runRNCCli.ts
@@ -1,10 +1,5 @@
 import { type SpawnOptions } from 'node:child_process';
 import { spawn } from './spawn';
-import path from 'node:path';
-import fs from 'fs-extra';
-import assert from 'node:assert';
-
-const NODE_BINARY = 'node';
 
 /**
  * Runs the React Native Community CLI with the specified arguments
@@ -15,37 +10,5 @@ export async function runRNCCli(
     stdio: 'ignore',
   }
 ) {
-  const rncCliBinaryName = await getCliBinaryName();
-
-  const RNC_CLI_BINARY_PATH = path.resolve(
-    process.cwd(), // We are always expected to run in the library
-    'node_modules',
-    '.bin',
-    rncCliBinaryName
-  );
-
-  return await spawn(RNC_CLI_BINARY_PATH, args, options);
-}
-
-async function getCliBinaryName(): Promise<string> {
-  const rncCliPackagePath = await spawn(NODE_BINARY, [
-    '-e',
-    `console.log(require.resolve('@react-native-community/cli/package.json'))`,
-  ]);
-
-  const rncCliPackage = await fs.readJson(rncCliPackagePath);
-  const binProperty = rncCliPackage.bin as Record<string, string>;
-  assert(
-    typeof binProperty === 'object',
-    "React Native CLI doesn't specify proper binaries"
-  );
-
-  const binaries = Object.keys(binProperty);
-  const rncCliBinaryName = binaries[0] as string;
-  assert(
-    typeof rncCliBinaryName === 'string',
-    "React Native Community CLI doesn't have any binaries to run"
-  );
-
-  return rncCliBinaryName;
+  return await spawn('npx', ['@react-native-community/cli', ...args], options);
 }


### PR DESCRIPTION
### Summary

Fixes #691

We created a custom way of calling the React Native Community CLI with #685. But it broke the easy workflow with monorepos. We made the original change to be able to call codegen build from XCode actions but since we dropped the support for that, we can revert the change back. This keeps the new file but uses the old method of calling the cil (npx).

### Test plan

1. Create a new project that supports the new architecture
2. Call `yarn prepare` and make sure everything passes.
