### PR TITLE
feat: allow to specify JSX Runtime for @babel/preset-react`

### DIFF
--- a/docs/pages/build.md
+++ b/docs/pages/build.md
@@ -139,7 +139,7 @@ yarn add --dev react-native-builder-bob
 
    > Note: If you enable Codegen generated code shipping, React Native won't build the scaffold code automatically when you build your test app. You need to rebuild the codegen scaffold code manually each time you make changes to your spec. If you want to automate this process, you can create a new project with `create-react-native-library` and inspect the example app.
 
-   ##### Opting out of Codegen shipping **(not recommended)**
+   ##### Opting out of Codegen shipping __(not recommended)__
 
    If you have a reason to not ship Codegen generated scaffold code with your library, you need to remove the [codegen target](#codegen) and add `package.json` to your `exports` field. Otherwise, React Native Codegen will skip spec generation for your library when your library is consumed as an NPM library. You can find the related issue [here](https://github.com/callstack/react-native-builder-bob/issues/637).
 

--- a/docs/pages/build.md
+++ b/docs/pages/build.md
@@ -139,7 +139,7 @@ yarn add --dev react-native-builder-bob
 
    > Note: If you enable Codegen generated code shipping, React Native won't build the scaffold code automatically when you build your test app. You need to rebuild the codegen scaffold code manually each time you make changes to your spec. If you want to automate this process, you can create a new project with `create-react-native-library` and inspect the example app.
 
-   ##### Opting out of Codegen shipping __(not recommended)__
+   ##### Opting out of Codegen shipping **(not recommended)**
 
    If you have a reason to not ship Codegen generated scaffold code with your library, you need to remove the [codegen target](#codegen) and add `package.json` to your `exports` field. Otherwise, React Native Codegen will skip spec generation for your library when your library is consumed as an NPM library. You can find the related issue [here](https://github.com/callstack/react-native-builder-bob/issues/637).
 
@@ -237,6 +237,10 @@ Example:
 ```json
 ["module", { "esm": true, "sourceMaps": false }]
 ```
+
+##### `jsxRuntime`
+
+Explicitly set your [runtime](https://babeljs.io/docs/babel-preset-react#runtime). Defaults to `automatic`.
 
 #### `typescript`
 

--- a/packages/react-native-builder-bob/babel-preset.js
+++ b/packages/react-native-builder-bob/babel-preset.js
@@ -6,6 +6,7 @@ const browserslist = require('browserslist');
  * Babel preset for React Native Builder Bob
  * @param {'commonjs' | 'preserve'} options.modules - Whether to compile modules to CommonJS or preserve them
  * @param {Boolean} options.esm - Whether to output ES module compatible code, e.g. by adding extension to import/export statements
+ * @param {'automatic' | 'classic'} options.jsxRuntime - Which JSX runtime to use, defaults to 'automatic'
  */
 module.exports = function (api, options, cwd) {
   const cjs = options.modules === 'commonjs';
@@ -37,7 +38,8 @@ module.exports = function (api, options, cwd) {
       [
         require.resolve('@babel/preset-react'),
         {
-          runtime: options.jsxRuntime || 'automatic',
+          runtime:
+            options.jsxRuntime !== undefined ? options.jsxRuntime : 'automatic',
         },
       ],
       require.resolve('@babel/preset-typescript'),

--- a/packages/react-native-builder-bob/babel-preset.js
+++ b/packages/react-native-builder-bob/babel-preset.js
@@ -37,7 +37,7 @@ module.exports = function (api, options, cwd) {
       [
         require.resolve('@babel/preset-react'),
         {
-          runtime: 'automatic',
+          runtime: options.jsxRuntime || 'automatic',
         },
       ],
       require.resolve('@babel/preset-typescript'),

--- a/packages/react-native-builder-bob/src/utils/compile.ts
+++ b/packages/react-native-builder-bob/src/utils/compile.ts
@@ -13,6 +13,7 @@ type Options = Input & {
   copyFlow?: boolean;
   modules: 'commonjs' | 'preserve';
   exclude: string;
+  jsxRuntime?: 'automatic' | 'classic';
 };
 
 const sourceExt = /\.([cm])?[jt]sx?$/;
@@ -29,6 +30,7 @@ export default async function compile({
   copyFlow,
   sourceMaps = true,
   report,
+  jsxRuntime = 'automatic',
 }: Options) {
   const files = glob.sync('**/*', {
     cwd: source,
@@ -113,6 +115,7 @@ export default async function compile({
                       // If a file is explicitly marked as ESM, then preserve the syntax
                       /\.m[jt]s$/.test(filepath) ? 'preserve' : modules,
                     esm,
+                    jsxRuntime,
                   },
                 ],
               ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In https://github.com/callstack/react-native-builder-bob/commit/0595213e4814c9bc34c270ef89bf31f8e0bd9bed the JSX runtime was changed to `automatic` without the option for the user to opt back in for `classic`.

The `classic` runtime is needed for NativeWind library, which is dependent on Reanimated.

Fixes
- https://github.com/software-mansion/react-native-reanimated/issues/6665
- #678 

### Test plan

🚀
