### PR TITLE
fix: use proper codegen types

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -198,7 +198,7 @@
   },
   "codegenConfig": {
     "name": "RN<%- project.name -%><%- project.view ? 'View': '' -%>Spec",
-    "type": "all",
+    "type": "<%- project.view ? 'components': 'modules' -%>",
     "jsSrcsDir": "src",
     "outputDir": {
       "ios": "ios/generated",

--- a/packages/react-native-builder-bob/src/__tests__/patchCodegenAndroidPackage.test.ts
+++ b/packages/react-native-builder-bob/src/__tests__/patchCodegenAndroidPackage.test.ts
@@ -61,7 +61,11 @@ describe('patchCodegenAndroidPackage', () => {
   });
 
   it('moves the files to correct dir', async () => {
-    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(
+      mockProjectPath,
+      mockPackageJson,
+      mockReport
+    );
 
     const expectedDir = path.resolve(
       mockProjectPath,
@@ -72,7 +76,11 @@ describe('patchCodegenAndroidPackage', () => {
   });
 
   it('replaces the package name in the files', async () => {
-    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(
+      mockProjectPath,
+      mockPackageJson,
+      mockReport
+    );
 
     const expectedDir = path.resolve(
       mockProjectPath,
@@ -87,7 +95,11 @@ describe('patchCodegenAndroidPackage', () => {
   });
 
   it('removes the old package dir', async () => {
-    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(
+      mockProjectPath,
+      mockPackageJson,
+      mockReport
+    );
 
     expect(await fs.pathExists(mockCodegenSpecsPath)).toBe(false);
   });

--- a/packages/react-native-builder-bob/src/__tests__/patchCodegenAndroidPackage.test.ts
+++ b/packages/react-native-builder-bob/src/__tests__/patchCodegenAndroidPackage.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe, beforeEach, afterEach } from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'node:path';
-import { patchCodegen } from '../utils/patchCodegen';
+import { patchCodegenAndroidPackage } from '../utils/patchCodegenAndroidPackage';
 import mockfs from 'mock-fs';
 import type { Report } from '../types';
 
@@ -44,7 +44,7 @@ const mockCodegenSpecsPath = path.resolve(
   'android/generated/java/com/facebook/fbreact/specs'
 );
 
-describe('patchCodegen', () => {
+describe('patchCodegenAndroidPackage', () => {
   beforeEach(() => {
     mockfs({
       [mockProjectPath]: {
@@ -61,7 +61,7 @@ describe('patchCodegen', () => {
   });
 
   it('moves the files to correct dir', async () => {
-    await patchCodegen(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
 
     const expectedDir = path.resolve(
       mockProjectPath,
@@ -72,7 +72,7 @@ describe('patchCodegen', () => {
   });
 
   it('replaces the package name in the files', async () => {
-    await patchCodegen(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
 
     const expectedDir = path.resolve(
       mockProjectPath,
@@ -87,7 +87,7 @@ describe('patchCodegen', () => {
   });
 
   it('removes the old package dir', async () => {
-    await patchCodegen(mockProjectPath, mockPackageJson, mockReport);
+    await patchCodegenAndroidPackage(mockProjectPath, mockPackageJson, mockReport);
 
     expect(await fs.pathExists(mockCodegenSpecsPath)).toBe(false);
   });

--- a/packages/react-native-builder-bob/src/targets/codegen.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen.ts
@@ -32,11 +32,13 @@ export default async function build({ root, report }: Options) {
     await del([codegenAndroidPath]);
   }
 
-  const codegenType = packageJson.codegenConfig?.type
+  const codegenType = packageJson.codegenConfig?.type;
 
   if (codegenType === undefined) {
-    report.error("Couldn't find the 'type' value in 'codegenConfig'. Please check your package.json's 'codegenConfig' property and make sure 'type' is defined. https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen")
-    process.exit(1)
+    report.error(
+      "Couldn't find the 'type' value in 'codegenConfig'. Please check your package.json's 'codegenConfig' property and make sure 'type' is defined. https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen"
+    );
+    process.exit(1);
   }
 
   try {

--- a/packages/react-native-builder-bob/src/targets/codegen.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen.ts
@@ -1,6 +1,6 @@
 import kleur from 'kleur';
 import type { Input } from '../types';
-import { patchCodegen } from '../utils/patchCodegen';
+import { patchCodegenAndroidPackage } from '../utils/patchCodegenAndroidPackage';
 import fs from 'fs-extra';
 import path from 'path';
 import del from 'del';
@@ -32,10 +32,19 @@ export default async function build({ root, report }: Options) {
     await del([codegenAndroidPath]);
   }
 
+  const codegenType = packageJson.codegenConfig?.type
+
+  if (codegenType === undefined) {
+    report.error("Couldn't find the 'type' value in 'codegenConfig'. Please check your package.json's 'codegenConfig' property and make sure 'type' is defined. https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen")
+    process.exit(1)
+  }
+
   try {
     await runRNCCli(['codegen']);
 
-    await patchCodegen(root, packageJson, report);
+    if (codegenType === 'modules' || codegenType === 'all') {
+      await patchCodegenAndroidPackage(root, packageJson, report);
+    }
 
     report.success('Generated native code with codegen');
   } catch (e: unknown) {

--- a/packages/react-native-builder-bob/src/utils/patchCodegenAndroidPackage.ts
+++ b/packages/react-native-builder-bob/src/utils/patchCodegenAndroidPackage.ts
@@ -13,7 +13,7 @@ const CODEGEN_DOCS =
  * @throws if codegenConfig.outputDir.android or codegenConfig.android.javaPackageName is not defined in package.json
  * @throws if the codegenAndroidPath does not exist
  */
-export async function patchCodegen(
+export async function patchCodegenAndroidPackage(
   projectPath: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJson: any,


### PR DESCRIPTION
### Summary

We were using `type: "all"` in codegenConfig for all types of libraries. @cipolleschi recommended us to use proper types instead [in this thread](https://github.com/facebook/react-native/issues/46208#issuecomment-2491424662). This updates the templates to use the proper types

### Test plan

#### Modules

1. Create a new arch supported module library
2. Go to the `package.json` and make sure `codegenConfig.type` is `"modules"`
3. Make sure the library builds and runs fine with the new architecture

#### Components a.k.a views

1. Create a new arch supported view/component
2. Go to the `package.json` and make sure `codegenConfig.type` is `"components"`
3. 3. Make sure the library builds and runs fine with the new architecture

