### PR TITLE
fix: fix deleting .tsbuildinfo file

### DIFF
--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -156,8 +156,15 @@ export default async function build({
       );
     }
 
+    const outputs = options?.esm
+      ? {
+          commonjs: path.join(output, 'commonjs'),
+          module: path.join(output, 'module'),
+        }
+      : { commonjs: output };
+
     const tsbuildinfo = path.join(
-      output,
+      outputs.commonjs,
       project.replace(/\.json$/, '.tsbuildinfo')
     );
 
@@ -166,13 +173,6 @@ export default async function build({
     } catch (e) {
       // Ignore
     }
-
-    const outputs = options?.esm
-      ? {
-          commonjs: path.join(output, 'commonjs'),
-          module: path.join(output, 'module'),
-        }
-      : { commonjs: output };
 
     const result = spawn.sync(
       tsc,


### PR DESCRIPTION
After adding ESM support, the path for `.tsbuildinfo` changed, but the code still referred to the previous path. This fixes the code to use the correct path.