### PR TITLE
Fix: Ensure 'invokeLibraryCodegen' task executes 'npx' correctly on all OS

### DIFF
--- a/packages/create-react-native-library/src/exampleApp/addCodegenBuildScript.ts
+++ b/packages/create-react-native-library/src/exampleApp/addCodegenBuildScript.ts
@@ -10,8 +10,14 @@ def isNewArchitectureEnabled() {
 if (isNewArchitectureEnabled()) {
     // Since our library doesn't invoke codegen automatically we need to do it here.
     tasks.register('invokeLibraryCodegen', Exec) {
-        workingDir "$rootDir/../../"
-        commandLine "npx", "bob", "build", "--target", "codegen"
+      workingDir "$rootDir/../../"
+      def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
+
+      if (isWindows) {
+        commandLine 'cmd', '/c', 'npx bob build --target codegen'
+      } else {
+        commandLine 'sh', '-c', 'npx bob build --target codegen'
+      }
     }
     preBuild.dependsOn invokeLibraryCodegen
 }`;


### PR DESCRIPTION
@IMPORTANT

feel free to close it if it only fails because a local configuration is incorrect.

### Summary

Fixed the error "Execution failed for task ':app:invokeLibraryCodegen'" when running yarn android in the Fabric View Library. The invokeLibraryCodegen task now correctly executes npx on all platforms by checking the OS and using cmd or sh accordingly.

### Test plan

Before the fix: Run `yarn android` on example forlder and observe the build failing with the mentioned error.
Apply the fix: Update the build script with the provided solution.
After the fix: Run yarn android again and confirm that the build succeeds without errors.