### PR TITLE
fix: fix incorrect check for --react-native-version

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -82,7 +82,7 @@ async function create(_argv: yargs.Arguments<Args>) {
 
   await fs.mkdirp(folder);
 
-  if (answers.reactNativeVersion !== null) {
+  if (answers.reactNativeVersion != null) {
     printUsedRNVersion(answers.reactNativeVersion, config);
   }
 


### PR DESCRIPTION
Currently when generating a project, it prints `Using react-native@undefined for the example` due to incorrect check for `undefined` and `null`.
