### PR TITLE
chore: migrate TurboReactPackage to BaseReactPackage

### DIFF
--- a/packages/create-react-native-library/templates/kotlin-library-mixed/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Package.kt
+++ b/packages/create-react-native-library/templates/kotlin-library-mixed/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Package.kt
@@ -1,13 +1,13 @@
 package com.<%- project.package %>
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.module.model.ReactModuleInfo
 import java.util.HashMap
 
-class <%- project.name -%>Package : TurboReactPackage() {
+class <%- project.name -%>Package : BaseReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     return if (name == <%- project.name -%>Module.NAME) {
       <%- project.name -%>Module(reactContext)

--- a/packages/create-react-native-library/templates/kotlin-library-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Package.kt
+++ b/packages/create-react-native-library/templates/kotlin-library-new/android/src/main/java/com/{%- project.package_dir %}/{%- project.name %}Package.kt
@@ -1,13 +1,13 @@
 package com.<%- project.package %>
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import java.util.HashMap
 
-class <%- project.name -%>Package : TurboReactPackage() {
+class <%- project.name -%>Package : BaseReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     return if (name == <%- project.name -%>Module.NAME) {
       <%- project.name -%>Module(reactContext)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

`TurboReactPackage` is deprecated in favor of `BaseReactPackage`.

https://github.com/facebook/react-native/pull/48039/files

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
