### PR TITLE
fix: use 'all' for fabric components codegen config

### DIFF
--- a/packages/create-react-native-library/templates/common-local/$package.json
+++ b/packages/create-react-native-library/templates/common-local/$package.json
@@ -6,7 +6,7 @@
 <% if (project.arch !== 'legacy') { -%>
   "codegenConfig": {
     "name": "RN<%- project.name -%><%- project.view ? 'View': '' -%>Spec",
-    "type": <%- project.view ? '"components"': '"modules"' %>,
+    "type": <%- project.view ? '"all"': '"modules"' %>,
     "jsSrcsDir": "src"
   },
 <% } -%>

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -198,7 +198,7 @@
   },
   "codegenConfig": {
     "name": "RN<%- project.name -%><%- project.view ? 'View': '' -%>Spec",
-    "type": "<%- project.view ? 'components': 'modules' -%>",
+    "type": "<%- project.view ? 'all': 'modules' -%>",
     "jsSrcsDir": "src",
     "outputDir": {
       "ios": "ios/generated",
@@ -209,7 +209,7 @@
     <% if (example === 'vanilla') { -%>
     },
     "includesGeneratedCode": true
-    <% } else { -%>    
+    <% } else { -%>
     }
     <% } -%>
 <% } -%>


### PR DESCRIPTION
currently codegen doesn't generate all required files such as `Android.mk`, `CMakeLists.txt` etc. for fabric when type is set to `components`. so we use `all` for now until this bug is fixed.

closes #661