### PR TITLE
refactor: make type option readable and refactor workflow

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -30,44 +30,30 @@ jobs:
           - ubuntu-latest
           - macos-14 # macos latest defaults to macos 12 at the moment.
         type:
-          - module-legacy
-          - module-new
-          - view-legacy
-          - view-new
+          - turbo-module
+          - fabric-view
+          - legacy-module
+          - legacy-view
         language:
           - kotlin-objc
           - kotlin-swift
-        arch:
-          - auto
+          - cpp
         exclude:
-          - type: module-new
+          - type: turbo-module
             language: kotlin-swift
-          - type: view-new
+          - type: fabric-view
             language: kotlin-swift
+          - type: fabric-view
+            language: cpp
+          - type: legacy-module
+            language: cpp
         include:
           - os: ubuntu-latest
             type: library
             language: js
-            arch: auto
-          - os: ubuntu-latest
-            type: module-legacy
-            language: cpp
-            arch: auto
-          - os: ubuntu-latest
-            type: module-new
-            language: cpp
-            arch: auto
-          - os: macos-14
-            type: module-legacy
-            language: cpp
-            arch: auto
-          - os: macos-14
-            type: module-new
-            language: cpp
-            arch: auto
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.type }}-${{ matrix.language }}-${{ matrix.arch }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.type }}-${{ matrix.language }}
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
@@ -79,20 +65,13 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Set environment variables
-        run: |
-          if [[ "${{ matrix.arch }}" == "new" ]]; then
-            echo "RCT_NEW_ARCH_ENABLED=1" >> $GITHUB_ENV
-            echo "ORG_GRADLE_PROJECT_newArchEnabled=true" >> $GITHUB_ENV
-          fi
-
       - name: Build package
         run: |
           yarn workspace create-react-native-library prepare
 
       - name: Get working directory
         run: |
-          echo "work_dir=${{ matrix.os }}-${{ matrix.type }}-${{ matrix.language }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "work_dir=${{ matrix.os }}-${{ matrix.type }}-${{ matrix.language }}" >> $GITHUB_ENV
 
       - name: Create library
         run: |
@@ -142,14 +121,14 @@ jobs:
         run: |
           # Build Android for only some matrices to skip redundant builds
           if [[ ${{ matrix.os }} == ubuntu-latest ]]; then
-            if [[ ${{ matrix.type }} == view-* && ${{ matrix.language }} == *-objc ]] || [[ ${{ matrix.type }} == module-* && ${{ matrix.language }} == *-objc ]] || [[ ${{ matrix.type }} == module-* && ${{ matrix.language }} == cpp ]]; then
+            if [[ ${{ matrix.type }} == *-view && ${{ matrix.language }} == *-objc ]] || [[ ${{ matrix.type }} == *-module && ${{ matrix.language }} == *-objc ]] || [[ ${{ matrix.type }} == *-module && ${{ matrix.language }} == cpp ]]; then
               echo "android_build=1" >> $GITHUB_ENV
             fi
           fi
 
           # Build iOS for only some matrices to skip redundant builds
           if [[ ${{ matrix.os }} == macos-14 ]]; then
-            if [[ ${{ matrix.type }} == view-* && ${{ matrix.language }} == kotlin-* ]] || [[ ${{ matrix.type }} == module-* && ${{ matrix.language }} == kotlin-* ]] || [[ ${{ matrix.type }} == module-* && ${{ matrix.language }} == cpp ]]; then
+            if [[ ${{ matrix.type }} == *-view && ${{ matrix.language }} == kotlin-* ]] || [[ ${{ matrix.type }} == *-module && ${{ matrix.language }} == kotlin-* ]] || [[ ${{ matrix.type }} == *-module && ${{ matrix.language }} == cpp ]]; then
               echo "ios_build=1" >> $GITHUB_ENV
             fi
           fi
@@ -160,9 +139,9 @@ jobs:
         with:
           path: |
             ${{ env.work_dir }}/.turbo
-          key: ${{ runner.os }}-library-turborepo-${{ matrix.type }}-${{ matrix.language }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/yarn.lock', env.work_dir)) }}
+          key: ${{ runner.os }}-library-turborepo-${{ matrix.type }}-${{ matrix.language }}-${{ hashFiles(format('{0}/yarn.lock', env.work_dir)) }}
           restore-keys: |
-            ${{ runner.os }}-library-turborepo-${{ matrix.type }}-${{ matrix.language }}-${{ matrix.arch }}-
+            ${{ runner.os }}-library-turborepo-${{ matrix.type }}-${{ matrix.language }}-
 
       - name: Check turborepo cache
         if: env.android_build == 1 || env.ios_build == 1

--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -121,7 +121,7 @@ async function create(_argv: yargs.Arguments<Args>) {
       : devDependencies;
   }
 
-  if (config.example === 'vanilla' && config.project.arch !== 'legacy') {
+  if (config.example === 'vanilla' && config.project.arch === 'new') {
     addCodegenBuildScript(folder);
   }
 

--- a/packages/create-react-native-library/src/input.ts
+++ b/packages/create-react-native-library/src/input.ts
@@ -21,10 +21,10 @@ export type ArgName =
 export type ProjectLanguages = 'kotlin-objc' | 'kotlin-swift' | 'cpp' | 'js';
 
 export type ProjectType =
-  | 'module-new'
-  | 'view-new'
-  | 'module-legacy'
-  | 'view-legacy'
+  | 'turbo-module'
+  | 'fabric-view'
+  | 'legacy-module'
+  | 'legacy-view'
   | 'library';
 
 const LANGUAGE_CHOICES: {
@@ -35,17 +35,17 @@ const LANGUAGE_CHOICES: {
   {
     title: 'Kotlin & Objective-C',
     value: 'kotlin-objc',
-    types: ['module-new', 'view-new', 'module-legacy', 'view-legacy'],
+    types: ['turbo-module', 'fabric-view', 'legacy-module', 'legacy-view'],
   },
   {
     title: 'Kotlin & Swift',
     value: 'kotlin-swift',
-    types: ['module-legacy', 'view-legacy'],
+    types: ['legacy-module', 'legacy-view'],
   },
   {
     title: 'C++ for Android & iOS',
     value: 'cpp',
-    types: ['module-new', 'module-legacy'],
+    types: ['turbo-module', 'legacy-module'],
   },
   {
     title: 'JavaScript for Android, iOS & Web',
@@ -86,22 +86,22 @@ const TYPE_CHOICES: {
 }[] = [
   {
     title: 'Turbo module',
-    value: 'module-new',
+    value: 'turbo-module',
     description: 'integration for native APIs to JS',
   },
   {
     title: 'Fabric view',
-    value: 'view-new',
+    value: 'fabric-view',
     description: 'integration for native views to JS',
   },
   {
     title: 'Legacy Native module',
-    value: 'module-legacy',
+    value: 'legacy-module',
     description: 'bridge for native APIs to JS (old architecture)',
   },
   {
     title: 'Legacy Native view',
-    value: 'view-legacy',
+    value: 'legacy-view',
     description: 'bridge for native views to JS (old architecture)',
   },
   {

--- a/packages/create-react-native-library/src/template.ts
+++ b/packages/create-react-native-library/src/template.ts
@@ -104,7 +104,7 @@ export function generateTemplateConfiguration({
   const { slug, languages, type } = answers;
 
   const arch =
-    type === 'module-legacy' || type === 'view-legacy' ? 'legacy' : 'new';
+    type === 'legacy-module' || type === 'legacy-view' ? 'legacy' : 'new';
 
   const project = slug.replace(/^(react-native-|@[^/]+\/)/, '');
   let namespace: string | undefined;
@@ -144,8 +144,8 @@ export function generateTemplateConfiguration({
       arch,
       cpp: languages === 'cpp',
       swift: languages === 'kotlin-swift',
-      view: answers.type.startsWith('view'),
-      module: answers.type.startsWith('module'),
+      view: answers.type.endsWith('-view'),
+      module: answers.type.endsWith('-module'),
     },
     author: {
       name: answers.authorName,

--- a/packages/create-react-native-library/templates/common-local/$package.json
+++ b/packages/create-react-native-library/templates/common-local/$package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "<%- project.description %>",
   "main": "src/index",
-<% if (project.arch !== 'legacy') { -%>
+<% if (project.arch === 'new') { -%>
   "codegenConfig": {
     "name": "RN<%- project.name -%><%- project.view ? 'View': '' -%>Spec",
     "type": <%- project.view ? '"all"': '"modules"' %>,

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -172,7 +172,7 @@
     "source": "src",
     "output": "lib",
     "targets": [
-<% if (project.arch !== 'legacy') { -%>
+<% if (project.arch === 'new') { -%>
       "codegen",
 <% } -%>
       [
@@ -194,7 +194,7 @@
         }
       ]
     ]
-<% if (project.arch !== 'legacy') { -%>
+<% if (project.arch === 'new') { -%>
   },
   "codegenConfig": {
     "name": "RN<%- project.name -%><%- project.view ? 'View': '' -%>Spec",

--- a/packages/create-react-native-library/templates/common/CONTRIBUTING.md
+++ b/packages/create-react-native-library/templates/common/CONTRIBUTING.md
@@ -49,7 +49,7 @@ To run the example app on iOS:
 yarn example ios
 ```
 
-<% if (project.arch !== 'legacy') { -%>
+<% if (project.arch === 'new') { -%>
 To confirm that the app is running with the new architecture, you can check the Metro logs for a message like this:
 
 ```sh


### PR DESCRIPTION
This makes the `type` option more readable: e.g. `turbo-module` instead of `module-new`.

It also means our CI builds are easier to read without needing to translate module new to turbo module etc.