### PR TITLE
fix: bob codegen deletes view specs when codegen type is all

### DIFF
--- a/packages/react-native-builder-bob/src/targets/codegen/patches/patchCodegenAndroidPackage.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen/patches/patchCodegenAndroidPackage.ts
@@ -30,7 +30,7 @@ export async function patchCodegenAndroidPackage(
 
   if (!(await fs.pathExists(codegenAndroidPath))) {
     throw new Error(
-      `The codegen android path defined in your package.json: ${codegenAndroidPath} doesnt' exist.`
+      `The codegen android path defined in your package.json: ${codegenAndroidPath} doesn't exist.`
     );
   }
 
@@ -89,7 +89,19 @@ export async function patchCodegenAndroidPackage(
     })
   );
 
-  await fs.rm(path.resolve(codegenAndroidPath, 'java/com/facebook'), {
-    recursive: true,
-  });
+  if (
+    await fs.pathExists(
+      path.resolve(codegenAndroidPath, 'java/com/facebook/react/viewmanagers')
+    )
+  ) {
+    // Keep the view managers
+    await fs.rm(path.resolve(codegenAndroidPath, 'java/com/facebook/fbreact'), {
+      recursive: true,
+    });
+  } else {
+    // Delete the entire facebook namespace
+    await fs.rm(path.resolve(codegenAndroidPath, 'java/com/facebook'), {
+      recursive: true,
+    });
+  }
 }


### PR DESCRIPTION
### Summary

Fixes #728

The codegen patcher script was deleting the whole `facebook` namespace when the codegen type was all or module. This was not a problem when the type was module but when the type was all, view manager specs were also getting removed.s

### Test plan

1. Create a new turbo module
2. Set codegen type to all
3. Add turbo module specs
4. Run `yarn bob build --target codegen`
5. Make sure `android/generated/java/com/facebook/react` exists and has view manager specs
