### PR TITLE
fix: build architectures needed only for cpp projects

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -14,10 +14,12 @@ buildscript {
   }
 }
 
+<% if (project.cpp) { -%>
 def reactNativeArchitectures() {
   def value = rootProject.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
+<% } -%>
 
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"


### PR DESCRIPTION
### Summary

This PR adds an additional if statement for defining `reactNativeArchitectures` as its needed only for C++ projects.

### Test plan

CI Green
