### PR TITLE
fix: js-only libraries have codegen config

### DIFF
--- a/packages/create-react-native-library/src/template.ts
+++ b/packages/create-react-native-library/src/template.ts
@@ -104,7 +104,9 @@ export function generateTemplateConfiguration({
   const { slug, languages, type } = answers;
 
   const arch =
-    type === 'legacy-module' || type === 'legacy-view' ? 'legacy' : 'new';
+    type === 'legacy-module' || type === 'legacy-view' || type === 'library'
+      ? 'legacy'
+      : 'new';
 
   const project = slug.replace(/^(react-native-|@[^/]+\/)/, '');
   let namespace: string | undefined;

--- a/packages/create-react-native-library/templates/example-module-legacy/example/src/App.tsx
+++ b/packages/create-react-native-library/templates/example-module-legacy/example/src/App.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
 import { multiply } from '<%- project.slug -%>';
-
+import { Text, View, StyleSheet } from 'react-native';
 <% if (project.native) { -%>
+import { useState, useEffect } from 'react';
+
 export default function App() {
   const [result, setResult] = useState<number | undefined>();
 
@@ -11,6 +11,7 @@ export default function App() {
   }, []);
 
 <% } else { -%>
+
 const result = multiply(3, 7);
 
 export default function App() {

--- a/packages/create-react-native-library/templates/example-module-legacy/example/src/App.tsx
+++ b/packages/create-react-native-library/templates/example-module-legacy/example/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { multiply } from '<%- project.slug -%>';
 
+<% if (project.native) { -%>
 export default function App() {
   const [result, setResult] = useState<number | undefined>();
 
@@ -9,6 +10,11 @@ export default function App() {
     multiply(3, 7).then(setResult);
   }, []);
 
+<% } else { -%>
+const result = multiply(3, 7);
+
+export default function App() {
+<% } -%>
   return (
     <View style={styles.container}>
       <Text>Result: {result}</Text>


### PR DESCRIPTION
### Summary

Fixes #754

JS-only libraries were setting the new architecture flag on. While this is not a preferable mental modal, we had some code associated with codegen that checked this flag. With this PR, JS-only libraries will set this flag to false. This is not an optimal solution but we will fully drop this flag with the deprecation of the legacy arch in the upcoming months.

### Test plan

1. Generate a JavaScript-only library
1. Make sure the `codegen` target isn't added to bob targets in `package.json`
1. Make sure there is no `codegenConfig` in `package.json`
1. Make sure `yarn prepare` works.
