### PR TITLE
chore: upgrading the Bob fallback version to v0.36.0

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -20,7 +20,7 @@ import {
 import { getDependencyVersionsFromExampleApp } from './exampleApp/dependencies';
 import { printErrorHelp, printNextSteps, printUsedRNVersion } from './inform';
 
-const FALLBACK_BOB_VERSION = '0.32.0';
+const FALLBACK_BOB_VERSION = '0.36.0';
 
 yargs
   .command(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Upgrading the builder Bob fallback version to `v0.36.0`

I’ve been working on two recently created libraries, and both were failing to build for iOS due to duplicated symbols caused by codegen. I checked the Bob builder and saw that this issue was fixed in v0.35.3, but when creating a new library with `create-react-native-library`, it was resolving to v0.32.0. It seems the Bob version wasn’t resolving correctly and was falling back to v0.32.0. So, I upgraded the fallback version to the latest stable release.

### Test plan

Built for iOS, and CI completed successfully.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
