### PR TITLE
fix(crnl): fix nitro modules android template

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
   }
 }
 
-<% if (project.cpp) { -%>
+<% if (project.cpp || project.moduleConfig === 'nitro-modules') { -%>
 def reactNativeArchitectures() {
   def value = rootProject.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]

--- a/packages/create-react-native-library/templates/nitro-module/android/src/main/java/com/margelo/nitro/{%- project.package_dir %}/{%- project.name %}.kt
+++ b/packages/create-react-native-library/templates/nitro-module/android/src/main/java/com/margelo/nitro/{%- project.package_dir %}/{%- project.name %}.kt
@@ -1,7 +1,7 @@
 package com.margelo.nitro.<%- project.package %>
 
 @DoNotStrip
-class CrnlNitro : Hybrid<%- project.name %>Spec() {
+class <%- project.name %> : Hybrid<%- project.name %>Spec() {
   override fun multiply(a: Double, b: Double): Double {
     return a * b
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Android doesn't build at the moment when choosing the new nitro modules implementation.
These changes fixed my issues.
