### PR TITLE
fix: remove React-Codegen dependency from podspec

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -48,7 +48,6 @@ Pod::Spec.new do |s|
 <% if (project.viewConfig !== null) { -%>
       s.dependency "React-RCTFabric"
 <% } -%>
-      s.dependency "React-Codegen"
       s.dependency "RCT-Folly"
       s.dependency "RCTRequired"
       s.dependency "RCTTypeSafety"


### PR DESCRIPTION
### Summary

Looks like the libraries no longer depend on `React-Codegen` as of https://github.com/facebook/react-native/pull/47458. And `React-Codegen` was renamed to `ReactCodegen` so we haven't been using the proper target for a while now. This removes that form pod dependencies

### Test plan

1. Create a new architecture library
2. Make sure it builds on iOS
