### PR TITLE
chore: drop 0.71 support from podspec

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -29,5 +29,11 @@ Pod::Spec.new do |s|
   add_nitrogen_files(s)
 <% } -%>
 
+# Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+# See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
+if respond_to?(:install_modules_dependencies, true)
   install_modules_dependencies(s)
+else
+  s.dependency "React-Core"
+end
 end

--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "<%- project.name -%>"
@@ -30,29 +29,5 @@ Pod::Spec.new do |s|
   add_nitrogen_files(s)
 <% } -%>
 
-  # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
-  # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
-  if respond_to?(:install_modules_dependencies, true)
-    install_modules_dependencies(s)
-  else
-    s.dependency "React-Core"
-
-    # Don't install the dependencies when we run `pod install` in the old architecture.
-    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-      s.pod_target_xcconfig    = {
-          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-      }
-<% if (project.viewConfig !== null) { -%>
-      s.dependency "React-RCTFabric"
-<% } -%>
-      s.dependency "React-Codegen"
-      s.dependency "RCT-Folly"
-      s.dependency "RCTRequired"
-      s.dependency "RCTTypeSafety"
-      s.dependency "ReactCommon/turbomodule/core"
-    end
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
### Summary

Since React Native 0.75 is dropping support soon, I decided to remove this check for 0.71 this makes the `podspec` a lot cleaner.

### Test plan

CI Green