### PR TITLE
refactor: remove unnecessary checks for new arch

### DIFF
--- a/packages/create-react-native-library/src/exampleApp/addCodegenBuildScript.ts
+++ b/packages/create-react-native-library/src/exampleApp/addCodegenBuildScript.ts
@@ -3,28 +3,25 @@ import fs from 'fs-extra';
 
 // This is added to the example app's build.gradle file to invoke codegen before every build
 const GRADLE_INVOKE_CODEGEN_TASK = `
-def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+// Run Codegen during development for the example app.
+tasks.register('invokeLibraryCodegen', Exec) {
+  workingDir "$rootDir/../../"
+  def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
+
+  if (isWindows) {
+    commandLine 'cmd', '/c', 'npx bob build --target codegen'
+  } else {
+    commandLine 'sh', '-c', 'npx bob build --target codegen'
+  }
 }
 
-if (isNewArchitectureEnabled()) {
-    // Since our library doesn't invoke codegen automatically we need to do it here.
-    tasks.register('invokeLibraryCodegen', Exec) {
-      workingDir "$rootDir/../../"
-      def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
-
-      if (isWindows) {
-        commandLine 'cmd', '/c', 'npx bob build --target codegen'
-      } else {
-        commandLine 'sh', '-c', 'npx bob build --target codegen'
-      }
-    }
-    preBuild.dependsOn invokeLibraryCodegen
-}`;
+preBuild.dependsOn invokeLibraryCodegen
+`;
 
 // You need to have the files before calling pod install otherwise they won't be registered in your pod.
 // So we add a pre_install hook to the podfile that invokes codegen
 const PODSPEC_INVOKE_CODEGEN_SCRIPT = `
+  # Run Codegen during development for the example app.
   pre_install do |installer|
     system("cd ../../ && npx bob build --target codegen")
   end

--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -22,19 +22,15 @@ def reactNativeArchitectures() {
 }
 <% } -%>
 
-def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 <% if (project.moduleConfig === 'nitro-modules') { -%>
 apply from: '../nitrogen/generated/android/<%- project.package_cpp -%>+autolinking.gradle'
 <% } -%>
 
-if (isNewArchitectureEnabled()) {
-  apply plugin: "com.facebook.react"
-}
+<% if (project.arch === "new") { -%>
+apply plugin: "com.facebook.react"
+<% } -%>
 
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["<%- project.name -%>_" + name]).toInteger()
@@ -72,9 +68,6 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
-<% if (project.arch === "new") { -%>
-    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-<% } -%>
 <% if (project.cpp || project.moduleConfig === 'nitro-modules') { -%>
 
     externalNativeBuild {
@@ -154,12 +147,10 @@ android {
 
   sourceSets {
     main {
-      if (isNewArchitectureEnabled()) {
-          java.srcDirs += [
-            "generated/java",
-            "generated/jni"
-          ]
-      }
+      java.srcDirs += [
+        "generated/java",
+        "generated/jni"
+      ]
     }
   }
 <% } -%>
@@ -181,11 +172,9 @@ dependencies {
 }
 
 <% if (project.moduleConfig === "turbo-modules" || project.viewConfig === "fabric-view") { -%>
-if (isNewArchitectureEnabled()) {
-  react {
-    jsRootDir = file("../src/")
-    libraryName = "<%- project.viewConfig !== null ? project.name + 'View' : project.name -%>"
-    codegenJavaPackageName = "com.<%- project.package -%>"
-  }
+react {
+  jsRootDir = file("../src/")
+  libraryName = "<%- project.viewConfig !== null ? project.name + 'View' : project.name -%>"
+  codegenJavaPackageName = "com.<%- project.package -%>"
 }
 <% } -%>


### PR DESCRIPTION
Since we no longer have a backward compatible template, these checks are no longer necessary.