### PR TITLE
fix: prevent example app from adding newArchEnabled if already present

### DIFF
--- a/packages/create-react-native-library/src/exampleApp/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/exampleApp/generateExampleApp.ts
@@ -290,7 +290,9 @@ export default async function generateExampleApp({
           'newArchEnabled=false',
           'newArchEnabled=true'
         );
-      } else {
+      } else if (
+        !gradleProperties.split('\n').includes('newArchEnabled=true')
+      ) {
         gradleProperties += '\nnewArchEnabled=true';
       }
     }


### PR DESCRIPTION
### Summary

👋 Hey! I was creating a new library and noticed that the generated `example/android/gradle.properties` file had the `newArchEnabled=true` setting duplicated. I think it has to do with the vanilla example app now setting the flag to true by default ([@react-native-community/cli](https://github.com/react-native-community/cli)), but I can't point to a specific commit or dependency that causes it 🤷‍♂️.

In any case, the change should be safe even if they revert it so there's that.

### Test plan

- Create a new library with a vanilla example app and make sure the generated `example/android/gradle.properties` file has no duplicated `newArchEnabled=true` lines.
