### PR TITLE
refactor: drop commonjs build from default setup

### DIFF
--- a/docs/pages/build.md
+++ b/docs/pages/build.md
@@ -78,18 +78,11 @@ To configure your project manually, follow these steps:
 
    ```json
    "source": "./src/index.tsx",
-   "main": "./lib/commonjs/index.js",
-   "module": "./lib/module/index.js",
+   "main": "./lib/module/index.js",
    "exports": {
      ".": {
-       "import": {
-         "types": "./lib/typescript/module/src/index.d.ts",
-         "default": "./lib/module/index.js"
-       },
-       "require": {
-         "types": "./lib/typescript/commonjs/src/index.d.ts",
-         "default": "./lib/commonjs/index.js"
-       }
+        "types": "./lib/typescript/src/index.d.ts",
+        "default": "./lib/module/index.js"
      },
      "./package.json": "./package.json"
    },
@@ -248,7 +241,7 @@ Example:
 
 Enable compiling source files with Babel and use CommonJS module system. This is essentially the same as the `module` target and accepts the same options, but transforms the `import`/`export` statements in your code to `require`/`module.exports`.
 
-This is useful for supporting usage of this module with `require` in Node versions older than 20 (it can still be used with `import` for Node.js 12+ if `module` target with `esm` is enabled), and some tools such a [Jest](https://jestjs.io). The output file should be referenced in the `main` field. If you have a dual module setup with both ESM and CommonJS builds, it needs to be specified in `exports['.'].require` field of `package.json`.
+This is useful for supporting usage of this module with `require` in Node versions older than 20 (it can still be used with `import` for Node.js 12+ if `module` target with `esm` is enabled), and some tools such as [Jest](https://jestjs.io). The output file should be referenced in the `main` field. If you have a [dual package setup](esm.md#dual-package-setup) with both ESM and CommonJS builds, it needs to be specified in `exports['.'].require` field of `package.json`.
 
 Example:
 

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -3,18 +3,11 @@
   "version": "0.1.0",
   "description": "<%- project.description %>",
   "source": "./src/index.tsx",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/module/index.js",
+  "main": "./lib/module/index.js",
   "exports": {
     ".": {
-      "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
-      }
+      "types": "./lib/typescript/src/index.d.ts",
+      "default": "./lib/module/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -182,12 +175,6 @@
 <% } -%>
       [
         "module",
-        {
-          "esm": true
-        }
-      ],
-      [
-        "commonjs",
         {
           "esm": true
         }

--- a/packages/react-native-builder-bob/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/packages/react-native-builder-bob/src/__tests__/__snapshots__/init.test.ts.snap
@@ -9,20 +9,13 @@ exports[`initializes the configuration 1`] = `
   },
   "exports": {
     ".": {
-      "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
-      }
+      "types": "./lib/typescript/src/index.d.ts",
+      "default": "./lib/module/index.js"
     },
     "./package.json": "./package.json"
   },
   "source": "./src/index.ts",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/module/index.js",
+  "main": "./lib/module/index.js",
   "scripts": {
     "prepare": "bob build"
   },
@@ -39,12 +32,6 @@ exports[`initializes the configuration 1`] = `
     "targets": [
       [
         "module",
-        {
-          "esm": true
-        }
-      ],
-      [
-        "commonjs",
         {
           "esm": true
         }

--- a/packages/react-native-builder-bob/src/init.ts
+++ b/packages/react-native-builder-bob/src/init.ts
@@ -101,7 +101,7 @@ export async function init() {
         {
           title: 'commonjs - for legacy setups (Node.js < 20)',
           value: 'commonjs',
-          selected: true,
+          selected: false,
         },
         {
           title: 'typescript - declaration files for typechecking',
@@ -297,14 +297,6 @@ export async function init() {
     entryFields.main = entries.commonjs;
   } else if (targets.includes('module')) {
     entryFields.main = entries.module;
-  }
-
-  if (targets.includes('typescript') && !pkg.exports?.['.']) {
-    if (entryFields.main === entries.commonjs) {
-      entryFields.types = types.require;
-    } else {
-      entryFields.types = types.import;
-    }
   }
 
   for (const key in entryFields) {

--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -257,12 +257,14 @@ export default async function build({
                 name: "exports['.'].types",
                 value: pkg.exports?.['.']?.types,
                 output: outDir,
-                error: Boolean(esm && variants.commonjs && variants.module),
-                message: `using both ${kleur.blue('commonjs')} and ${kleur.blue(
-                  'module'
-                )} targets with ${kleur.blue(
-                  'esm'
-                )} option enabled. Specify ${kleur.blue(
+                error: Boolean(
+                  pkg.exports?.['.']?.import && pkg.exports?.['.']?.require
+                ),
+                message: `using  ${kleur.blue(
+                  "exports['.'].import"
+                )} and ${kleur.blue(
+                  "exports['.'].require"
+                )}. Specify ${kleur.blue(
                   "exports['.'].import.types"
                 )} and ${kleur.blue("exports['.'].require.types")} instead.`,
               },


### PR DESCRIPTION
There's a possibility of [dual package hazard](https://nodejs.org/docs/latest-v19.x/api/packages.html#dual-package-hazard) with the current setup. Metro enables `exports` support from [0.82.0](https://github.com/facebook/metro/releases/tag/v0.82.0), so this can become a problem for some packages.

So this drops the dual package setup in favor of an ESM-only setup. To make a similar change in your package, apply the following change to your entrypoints:

```diff
-  "main": "./lib/commonjs/index.js",
+  "main": "./lib/module/index.js",a
-  "types": "./lib/typescript/commonjs/src/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
-      }
+      "types": "./lib/typescript/src/index.d.ts",
+      "default": "./lib/module/index.js"
     }
   },
```

Also, remove the `commonjs` target from the `react-native-builder-bob` field in your `package.json` or `bob.config.js` or `bob.config.mjs`:

```diff
"react-native-builder-bob": {
  "source": "src",
  "output": "lib",
  "targets": [
    ["module", { "esm": true }],
-   ["commonjs", { "esm": true }]
    "typescript",
  ]
}
```

With this change, [Jest](https://jestjs.io/) will break for the consumers of your libraries due to the usage of ESM syntax. So they may need to update their Jest configuration to transform your library:

```js
module.exports = {
  preset: 'react-native',
+ transform: {
+   'node_modules/(your-library|another-library)': 'babel-jest',
+ },
};
```

If consumers of your library are using it in NodeJS in a CommonJS environment, they'll need to use at least NodeJS v20.19.0 to be able to synchronously `require` your library.

You can read more at our [ESM support docs](https://callstack.github.io/react-native-builder-bob/esm#dual-package-setup).