### PR TITLE
refactor: drop cosmiconfig

### DIFF
--- a/packages/react-native-builder-bob/package.json
+++ b/packages/react-native-builder-bob/package.json
@@ -29,7 +29,7 @@
     "babel-config.js"
   ],
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 20.19.0"
   },
   "publishConfig": {
     "access": "public",
@@ -53,7 +53,6 @@
     "@babel/preset-typescript": "^7.24.7",
     "babel-plugin-module-resolver": "^5.0.2",
     "browserslist": "^4.20.4",
-    "cosmiconfig": "^9.0.0",
     "cross-spawn": "^7.0.3",
     "dedent": "^0.7.0",
     "del": "^6.1.1",

--- a/packages/react-native-builder-bob/src/build.ts
+++ b/packages/react-native-builder-bob/src/build.ts
@@ -31,7 +31,7 @@ export async function build(argv: Argv) {
     );
   }
 
-  const result = await loadConfig();
+  const result = loadConfig(root);
 
   if (!result?.config) {
     logger.error(

--- a/packages/react-native-builder-bob/src/init.ts
+++ b/packages/react-native-builder-bob/src/init.ts
@@ -37,7 +37,7 @@ export async function init() {
   }
 
   const pkg = JSON.parse(await fs.readFile(projectPackagePath, 'utf-8'));
-  const result = await loadConfig();
+  const result = loadConfig(root);
 
   if (result?.config && pkg.devDependencies && name in pkg.devDependencies) {
     const { shouldContinue } = await prompts({

--- a/packages/react-native-builder-bob/src/utils/loadConfig.ts
+++ b/packages/react-native-builder-bob/src/utils/loadConfig.ts
@@ -1,19 +1,69 @@
-import { cosmiconfig } from 'cosmiconfig';
+import { join } from 'path';
+import { name } from '../../package.json';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports,import-x/no-commonjs
-const { name } = require('../../package.json');
+const searchPlaces = [
+  'bob.config.mjs',
+  'bob.config.cjs',
+  'bob.config.js',
+  'package.json',
+];
 
-const root = process.cwd();
-const explorer = cosmiconfig(name, {
-  stopDir: root,
-  searchPlaces: [
-    'package.json',
-    'bob.config.mjs',
-    'bob.config.cjs',
-    'bob.config.js',
-  ],
-});
+export const loadConfig = (root: string) => {
+  for (const filename of searchPlaces) {
+    const result = requireConfig(root, filename);
 
-export const loadConfig = async () => {
-  return explorer.search();
+    if (filename === 'package.json' && result != null) {
+      if (result.content[name] != null) {
+        return {
+          filepath: result.filepath,
+          config: result.content[name],
+        };
+      }
+    }
+
+    if (result != null) {
+      const content = result.content;
+
+      if (content?.__esModule) {
+        return {
+          filepath: result.filepath,
+          config: content.default,
+        };
+      }
+
+      return {
+        filepath: result.filepath,
+        config: content,
+      };
+    }
+  }
+
+  return undefined;
+};
+
+const requireConfig = (root: string, filename: string) => {
+  const filepath = join(root, filename);
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const content = require(filepath);
+
+    return {
+      filepath,
+      content,
+    };
+  } catch (e) {
+    if (
+      typeof e === 'object' &&
+      e != null &&
+      'code' in e &&
+      e.code === 'MODULE_NOT_FOUND'
+    ) {
+      // We expect that some of the config files won't exist
+      // So we just return undefined in that case
+      return undefined;
+    }
+
+    throw e;
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5562,23 +5562,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0"
-  dependencies:
-    env-paths: ^2.2.1
-    import-fresh: ^3.3.0
-    js-yaml: ^4.1.0
-    parse-json: ^5.2.0
-  peerDependencies:
-    typescript: ">=4.9.5"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: a30c424b53d442ea0bdd24cb1b3d0d8687c8dda4a17ab6afcdc439f8964438801619cdb66e8e79f63b9caa3e6586b60d8bab9ce203e72df6c5e80179b971fe8f
-  languageName: node
-  linkType: hard
-
 "create-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "create-jest@npm:29.7.0"
@@ -6491,7 +6474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
+"env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
@@ -12743,7 +12726,6 @@ __metadata:
     babel-plugin-module-resolver: ^5.0.2
     browserslist: ^4.20.4
     concurrently: ^7.2.2
-    cosmiconfig: ^9.0.0
     cross-spawn: ^7.0.3
     dedent: ^0.7.0
     del: ^6.1.1


### PR DESCRIPTION
### Summary

[cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) is no longer maintained. Apart from that, we can't support ESM configuration properly because `cosmiconfig` only supports loading it asynchronously - but we need to be able to load it synchronously in babel config.

I also took a look at [lilconfig](https://github.com/antonk52/lilconfig), but it also has the same limitation.

Node 20.19.0 onwards supports synchronous `require` of ESM, so this limitation is not a technical limitation. So I decided to implement config loading myself since we don't need any advanced features of these config loaders such as traversing up until they find the config.

### Test plan

Tested in a sample project with both `bob build` and in the example app with metro.
