### PR TITLE
fix(crnl): certain versions of XCode can't resolve codegen headers

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 <% } else if (project.arch !== "legacy") { -%>
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
-  s.private_header_files = "ios/generated/**/*.h"
+  s.private_header_files = "ios/**/*.h"
 <% } else { -%>
   s.source_files = "ios/**/*.{h,m,mm}"
 <% } -%>

--- a/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
+++ b/packages/create-react-native-library/templates/objc-library/ios/{%- project.name %}.h
@@ -5,7 +5,7 @@
 <% } -%>
 
 <% if (project.arch === 'new') { -%>
-#import "generated/RN<%- project.name -%>Spec/RN<%- project.name -%>Spec.h"
+#import <<%- project.name -%>/RN<%- project.name -%>Spec.h>
 
 @interface <%- project.name -%> : NSObject <Native<%- project.name -%>Spec>
 <% } else { -%>

--- a/packages/create-react-native-library/templates/objc-view-new/ios/{%- project.name %}View.mm
+++ b/packages/create-react-native-library/templates/objc-view-new/ios/{%- project.name %}View.mm
@@ -1,9 +1,9 @@
 #import "<%- project.name -%>View.h"
 
-#import "generated/RN<%- project.name -%>ViewSpec/ComponentDescriptors.h"
-#import "generated/RN<%- project.name -%>ViewSpec/EventEmitters.h"
-#import "generated/RN<%- project.name -%>ViewSpec/Props.h"
-#import "generated/RN<%- project.name -%>ViewSpec/RCTComponentViewHelpers.h"
+#import <<%- project.name -%>/ComponentDescriptors.h>
+#import <<%- project.name -%>/EventEmitters.h>
+#import <<%- project.name -%>/Props.h>
+#import <<%- project.name -%>/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 


### PR DESCRIPTION
### Summary

- Some people are having XCode build issues with new-architecture enabled libraries, fabric and turbo modules.
- The issues are related to XCode not being able to resolve `#import` directives following this pattern `generated/x/y.h`
- This PR changes the template so these headers are imported from the generated LLVM module using the module include paths such as: `<ModuleName/header.h>`
- Also made all the headers private. Otherwise the modules fail when user tries to add a Swift file. This is because cocoapods automatically generates an umbrella header based on all the available headers and the swift compilation step treats all headers in the umbrella header as objective-c headers. This in turn results in an error since some headers need objective-cpp features and cpp stdlib headers.

### Test plan

1. Create a turbo module and a fabric view separately
2. Make sure you're able to build the library on XCode 16.0, 16.1, and 16.2
