### PR TITLE
fix: pass source flag to codegen cli when possible

### DIFF
--- a/packages/create-react-native-library/src/index.ts
+++ b/packages/create-react-native-library/src/index.ts
@@ -20,7 +20,7 @@ import { createInitialGitCommit } from './utils/initialCommit';
 import { prompt } from './utils/prompt';
 import { resolveNpmPackageVersion } from './utils/resolveNpmPackageVersion';
 
-const FALLBACK_BOB_VERSION = '0.40.4';
+const FALLBACK_BOB_VERSION = '0.40.5';
 const FALLBACK_NITRO_MODULES_VERSION = '0.22.1';
 const SUPPORTED_REACT_NATIVE_VERSION = '0.78.2';
 

--- a/packages/react-native-builder-bob/src/targets/codegen/patches/removeCodegenAppLevelCode.ts
+++ b/packages/react-native-builder-bob/src/targets/codegen/patches/removeCodegenAppLevelCode.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { CODEGEN_DOCS } from './patchCodegenAndroidPackage';
+import { spawn } from '../../../utils/spawn';
 
 const FILES_TO_REMOVE = [
   'RCTAppDependencyProvider.h',
@@ -67,4 +68,19 @@ export async function removeCodegenAppLevelCode(
   );
 
   await Promise.allSettled([...androidPromises, ...iosPromises]);
+}
+
+/**
+ * Codegen generates a different set of files if the target is an app instead.
+ * The following commit adds support for a --source argument to support calling codegen as a library:
+ * https://github.com/facebook/react-native/commit/98b8f178110472e5fed97de80766c03b0b5e988c
+ * Here we just check if the --source argument is supported.
+ */
+export async function getCodegenCLISourceSupport(): Promise<boolean> {
+  const codegenCLIHelpOutput = await spawn('npx', [
+    '@react-native-community/cli',
+    'codegen',
+    '--help',
+  ]);
+  return codegenCLIHelpOutput.includes('--source');
 }


### PR DESCRIPTION
### Summary

https://github.com/facebook/react-native/commit/98b8f178110472e5fed97de80766c03b0b5e988c adds support for `--source` flag in `npx @react-native-community/cli codegen`. With this flag, we can opt out of our patch. With this PR, bob checks if this flag is supported and uses it if it is.

### Test plan

1. Generate a library with a React Native version that supports `--source`. (The baseline is `react-native@0.78.0`).
2. Run `yarn prepare`
3. Make sure the command runs with no errors
4. Check the `ios/generated` and make sure there are no `.podspec` files.
