### PR TITLE
fix: use react native babel config for node_modules

### DIFF
--- a/packages/create-react-native-library/src/exampleApp/dependencies.ts
+++ b/packages/create-react-native-library/src/exampleApp/dependencies.ts
@@ -16,7 +16,12 @@ export async function alignDependencyVersionsWithExampleApp(
     path.join(folder, 'example', 'package.json')
   );
 
-  const PACKAGES_TO_COPY = ['react', 'react-native', '@types/react'];
+  const PACKAGES_TO_COPY = [
+    'react',
+    'react-native',
+    '@types/react',
+    '@react-native/babel-preset',
+  ];
 
   if (
     config.example === 'vanilla' &&

--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -80,6 +80,7 @@
     "@react-native-community/cli": "15.0.0-alpha.2",
 <% } -%>
     "@react-native/eslint-config": "^0.78.0",
+    "@react-native/babel-preset": "0.78.2",
     "@release-it/conventional-changelog": "^9.0.2",
     "@types/jest": "^29.5.5",
     "@types/react": "^19.0.12",

--- a/packages/create-react-native-library/templates/common/babel.config.js
+++ b/packages/create-react-native-library/templates/common/babel.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   presets: ['module:react-native-builder-bob/babel-preset'],
+  overrides: [
+    {
+      include: /\/node_modules\//,
+      presets: ['module:@react-native/babel-preset'],
+    },
+  ],
 };


### PR DESCRIPTION
This uses the react native babel preset for compiling `node_modules` - mainly useful for tests, so that syntaxes such as Flow are handled.

Related to ##747