### PR TITLE
feat(crnl): install nitro modules dependency automatically for local modules

### DIFF
--- a/packages/create-react-native-library/src/inform.ts
+++ b/packages/create-react-native-library/src/inform.ts
@@ -3,24 +3,55 @@ import dedent from 'dedent';
 import type { TemplateConfiguration } from './template';
 import kleur from 'kleur';
 
-export async function printNextSteps({
-  local,
+export function printNonLocalLibNextSteps(config: TemplateConfiguration) {
+  const platforms = {
+    ios: { name: 'iOS', color: 'cyan' },
+    android: { name: 'Android', color: 'green' },
+    ...(config.example === 'expo'
+      ? ({ web: { name: 'Web', color: 'blue' } } as const)
+      : null),
+  } as const;
+
+  console.log(
+    dedent(`
+      ${kleur.magenta(
+        `${kleur.bold('Get started')} with the project`
+      )}${kleur.gray(':')}
+
+        ${kleur.gray('$')} yarn
+      ${Object.entries(platforms)
+        .map(
+          ([script, { name, color }]) => `
+      ${kleur[color](`Run the example app on ${kleur.bold(name)}`)}${kleur.gray(
+        ':'
+      )}
+
+        ${kleur.gray('$')} yarn example ${script}`
+        )
+        .join('\n')}
+
+      ${kleur.yellow(
+        `See ${kleur.bold('CONTRIBUTING.md')} for more details. Good luck!`
+      )}
+    `)
+  );
+}
+
+export function printLocalLibNextSteps({
   folder,
   config,
   linkedLocalLibrary,
   addedNitro,
   packageManager,
 }: {
-  local: boolean;
   folder: string;
   config: TemplateConfiguration;
   linkedLocalLibrary: boolean;
   addedNitro: boolean;
   packageManager: string;
 }) {
-  if (local) {
-    console.log(
-      dedent(`
+  console.log(
+    dedent(`
       ${kleur.magenta(
         `${kleur.bold('Get started')} with the project`
       )}${kleur.gray(':')}
@@ -51,40 +82,7 @@ export async function printNextSteps({
 
       ${kleur.yellow(`Good luck!`)}
     `)
-    );
-  } else {
-    const platforms = {
-      ios: { name: 'iOS', color: 'cyan' },
-      android: { name: 'Android', color: 'green' },
-      ...(config.example === 'expo'
-        ? ({ web: { name: 'Web', color: 'blue' } } as const)
-        : null),
-    } as const;
-
-    console.log(
-      dedent(`
-      ${kleur.magenta(
-        `${kleur.bold('Get started')} with the project`
-      )}${kleur.gray(':')}
-
-        ${kleur.gray('$')} yarn
-      ${Object.entries(platforms)
-        .map(
-          ([script, { name, color }]) => `
-      ${kleur[color](`Run the example app on ${kleur.bold(name)}`)}${kleur.gray(
-        ':'
-      )}
-
-        ${kleur.gray('$')} yarn example ${script}`
-        )
-        .join('\n')}
-
-      ${kleur.yellow(
-        `See ${kleur.bold('CONTRIBUTING.md')} for more details. Good luck!`
-      )}
-    `)
-    );
-  }
+  );
 }
 
 export function printErrorHelp(message: string, error: Error) {

--- a/packages/create-react-native-library/src/template.ts
+++ b/packages/create-react-native-library/src/template.ts
@@ -39,6 +39,7 @@ export type TemplateConfiguration = {
     email: string;
     url: string;
   };
+  /** Git repo URL */
   repo: string;
   example: ExampleApp;
   year: number;

--- a/packages/create-react-native-library/src/utils/local.ts
+++ b/packages/create-react-native-library/src/utils/local.ts
@@ -1,0 +1,99 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { prompt } from './prompt';
+import type { TemplateConfiguration } from '../template';
+import type { Args } from '../input';
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+};
+
+export async function promptLocalLibrary(argv: Args): Promise<boolean> {
+  if (typeof argv.local === 'boolean') {
+    return argv.local;
+  }
+
+  const hasPackageJson = findAppPackageJsonPath() !== null;
+  if (!hasPackageJson) {
+    return false;
+  }
+
+  // If we're under a project with package.json, ask the user if they want to create a local library
+  const answers = await prompt({
+    type: 'confirm',
+    name: 'local',
+    message: `Looks like you're under a project folder. Do you want to create a local library?`,
+    initial: true,
+  });
+
+  return answers.local;
+}
+
+/** @returns `true` if successfull */
+export async function addNitroDependencyToLocalLibrary(
+  config: TemplateConfiguration
+): Promise<boolean> {
+  if (config.versions.nitroModules === undefined) {
+    return false;
+  }
+
+  const appPackageJsonPath = await findAppPackageJsonPath();
+  if (appPackageJsonPath === null) {
+    return false;
+  }
+
+  const appPackageJson: PackageJson = await fs.readJson(appPackageJsonPath);
+  const dependencies = appPackageJson['dependencies'] ?? {};
+
+  dependencies['react-native-nitro-modules'] = config.versions.nitroModules;
+
+  appPackageJson['dependencies'] = dependencies;
+  await fs.writeJson(appPackageJsonPath, appPackageJson, {
+    spaces: 2,
+  });
+
+  return true;
+}
+
+/** @returns `true` if successfull */
+export async function linkLocalLibrary(
+  config: TemplateConfiguration,
+  folder: string,
+  packageManager: string
+): Promise<boolean> {
+  const appPackageJsonPath = await findAppPackageJsonPath();
+  if (appPackageJsonPath === null) {
+    return false;
+  }
+
+  const appPackageJson: PackageJson = await fs.readJson(appPackageJsonPath);
+
+  const isReactNativeProject = Boolean(
+    appPackageJson.dependencies?.['react-native']
+  );
+
+  if (!isReactNativeProject) {
+    return false;
+  }
+
+  const dependencies = appPackageJson['dependencies'] ?? {};
+  dependencies[config.project.slug] =
+    packageManager === 'yarn'
+      ? `link:./${path.relative(process.cwd(), folder)}`
+      : `file:./${path.relative(process.cwd(), folder)}`;
+
+  await fs.writeJSON(appPackageJsonPath, appPackageJson, {
+    spaces: 2,
+  });
+
+  return true;
+}
+
+async function findAppPackageJsonPath(): Promise<string | null> {
+  const cwdPackageJson = path.join(process.cwd(), 'package.json');
+  if (!(await fs.pathExists(cwdPackageJson))) {
+    return null;
+  }
+
+  return cwdPackageJson;
+}

--- a/packages/create-react-native-library/src/utils/packageManager.ts
+++ b/packages/create-react-native-library/src/utils/packageManager.ts
@@ -1,0 +1,8 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+export async function determinePackageManager() {
+  return (await fs.pathExists(path.join(process.cwd(), 'yarn.lock')))
+    ? 'yarn'
+    : 'npm';
+}


### PR DESCRIPTION
### Summary

- `create-react-native-library` will install `react-native-nitro-modules` automatically for local libraries.

### Test plan

1. Create a new RN app
2. Build the bob repo
3. Link `create-react-native-library` to your RN app
4. Run `create-react-native-library` in the app
5. Answer yes when you're asked if you want to create a native module
6. Select `Nitro Modules`
7. Make sure `react-native-nitro-modules` is added to your app's dependencies.
