### PR TITLE
chore: specify error origin in babel-config.js

### DIFF
--- a/packages/react-native-builder-bob/babel-config.js
+++ b/packages/react-native-builder-bob/babel-config.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const { loadConfig } = require('./lib/utils/loadConfig');
 
+const tag = '[react-native-builder-bob]'
+
 /**
  * Get Babel configuration for the example project.
  * This sets up appropriate presets and plugins for the library.
@@ -18,14 +20,14 @@ const getConfig = (defaultConfig, { root }) => {
   const result = loadConfig(root);
 
   if (result == null) {
-    throw new Error(`Couldn't find a valid configuration at ${root}.`);
+    throw new Error(`${tag} Couldn't find a valid configuration at ${root}.`);
   }
 
   const { source } = result.config;
 
   if (source == null) {
     throw new Error(
-      "Couldn't determine the source directory. Does your config specify a 'source' field?"
+      `${tag} Couldn't determine the source directory. Does your config specify a 'source' field?`
     );
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

I remember way back I removed the `source` field in package.json and was greeted with one of these errors. I then searched through node_modules to find the origin, since there wasn't much context. This could help.

### Test plan

I didn't test this yet.