### PR TITLE
fix(template): disable hierarchical lookup in Metro config to fix mod…

### DIFF
--- a/packages/create-react-native-library/templates/expo-library/example/metro.config.js
+++ b/packages/create-react-native-library/templates/expo-library/example/metro.config.js
@@ -16,5 +16,6 @@ const config = withMetroConfig(getDefaultConfig(__dirname), {
 });
 
 config.resolver.unstable_enablePackageExports = true;
+config.resolver.disableHierarchicalLookup = true;
 
 module.exports = config;


### PR DESCRIPTION
### Summary
While working with a **JavaScript Librar**y module generated using `create-react-native-library`, I encountered module resolution issues when integrating the library into an Expo-managed project. React components and other dependencies failed to load correctly, which was caused by Metro’s default hierarchical lookup behavior.

Upon reviewing the generated `metro.config.js`, I found that it did not explicitly disable hierarchical lookup. This was resolved by adding the following line:

```js
config.resolver.disableHierarchicalLookup = true;
```
### Error Encountered Without This Fix
When disableHierarchicalLookup is not set to true, the app throws this error at runtime:

![image](https://github.com/user-attachments/assets/c14b05e6-e575-49f4-999d-91c72a80ee9e)

This error typically indicates duplicate React instances or improper module resolution, both symptoms of Metro resolving dependencies from unexpected directories due to hierarchical lookup.

### Rationale
By default, Metro traverses parent directories when resolving modules, which can lead to:
- React components not loading
- Duplicate or conflicting dependency versions
- Unexpected module resolution behavior in monorepo or workspace environments

This is especially problematic when using Expo or working in monorepos, as described in the [Expo Monorepo Guide (Step 3)](https://docs.expo.dev/guides/monorepos/#3-different-versions-of-dependencies-must-be). To avoid this, Expo recommends explicitly setting `disableHierarchicalLookup` to true to ensure Metro resolves modules only from the expected local `node_modules` path.

### Affected File
This update applies to the `metro.config.js` generated when selecting:
```bash
? What type of library do you want to develop? › JavaScript Library
```
### Testing
To verify the fix:

1. Run the CLI command to create a new module:
    ```bash
    packages\create-react-native-library\bin\create-react-native-library.cmd
    ```
2. Select **JavaScript Library** as the module type.
3. After generation, open the file at `example/metro.config.js`.
4. Confirm that the line
    ```bash
    config.resolver.disableHierarchicalLookup = true;
    ```
    has been added.

This confirms that the updated configuration is correctly included in the generated example project.