### PR TITLE
feat: Enable 16 KB page size on Android

### DIFF
--- a/packages/create-react-native-library/templates/native-common/android/build.gradle
+++ b/packages/create-react-native-library/templates/native-common/android/build.gradle
@@ -51,7 +51,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
 
         buildTypes {


### PR DESCRIPTION
Enables support for 16 KB page sizes on Android.

Each Native Module library will need to add this for themselves too in their `build.gradle` file if they want to support 16 KB page sizes, but it's good to have it in the template now I think.

See [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes) for more information.