### PR TITLE
fix: Add `nitro.json` to npm package

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -20,6 +20,7 @@
     "cpp",
 <% if (project.moduleConfig === "nitro-modules") { -%>
     "nitrogen",
+    "nitro.json",
 <% } -%>
     "*.podspec",
     "react-native.config.js",


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
In a future version of Nitro, you will be able to import types (HybridObjects) from other libraries. For the import to work seamlessly, nitrogen needs to read the other library's `nitro.json`  so it knows which C++/Android/Swift namespace to import to resolve the foreign type. That's why the `nitro.json` file should be part of the npm package! :)
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
