### PR TITLE
Add missing configutation for nitro-modules

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -13,13 +13,32 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "<%- repo -%>.git", :tag => "#{s.version}" }
 
+<% if (project.moduleConfig !== "nitro-modules") { -%>
 <% if (project.swift) { -%>
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 <% } else { -%>
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
   s.private_header_files = "ios/**/*.h"
 <% } -%>
+<% } -%>
+
 <% if (project.moduleConfig === "nitro-modules") { -%>
+  s.source_files = [
+    # Implementation (Swift)
+    "ios/**/*.{swift}",
+    # Autolinking/Registration (Objective-C++)
+    "ios/**/*.{m,mm}",
+    # Implementation (C++ objects)
+    "cpp/**/*.{hpp,cpp}",
+  ]
+
+  s.pod_target_xcconfig = {
+    # C++ compiler flags, mainly for folly.
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES"
+  }
+
+  s.dependency 'React-jsi'
+  s.dependency 'React-callinvoker'
 
   load 'nitrogen/generated/ios/<%- project.name -%>+autolinking.rb'
   add_nitrogen_files(s)


### PR DESCRIPTION
### Summary
While creating a nitro-module using `npx create-react-native-library@latest` and debugging issues I ran to, I [noticed](https://github.com/mrousavy/nitro/issues/696#issuecomment-2978193359) there are missing configurations in the podspec.

Mainly the following was missing when building a nitro-module:

```ruby
  s.source_files = [
    # Implementation (Swift)
    "ios/**/*.{swift}",
    # Autolinking/Registration (Objective-C++)
    "ios/**/*.{m,mm}",
    # Implementation (C++ objects)
    "cpp/**/*.{hpp,cpp}",
  ]

  s.pod_target_xcconfig = {
    # C++ compiler flags, mainly for folly.
    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES"
  }

  s.dependency 'React-jsi'
  s.dependency 'React-callinvoker'
  ```

This fixes the compilation errors around not finding Folly, or the module not compiling.

### Test plan

I tested this locally by running the tool and having the correct generated file. 
