### PR TITLE
fix(template): remove invalid render property from bug report template

### DIFF
--- a/packages/create-react-native-library/templates/common/$.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/packages/create-react-native-library/templates/common/$.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,5 @@ body:
     attributes:
       label: Reproducible example repository 
       description: Please provide a link to a repository on GitHub with a reproducible example.
-      render: js
     validations:
       required: true


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Fix bug report issue template not displaying properly due to invalid `render: js` property.
- Removed invalid `render: js` property from bug report template
- Issue template now displays correctly in GitHub Issues interface


#### before
<img width="722" alt="image" src="https://github.com/user-attachments/assets/a29acf28-a1c0-4d17-9a97-777b4370b0fb" />

#### after

<img width="421" alt="image" src="https://github.com/user-attachments/assets/9f360b78-2f69-4bdc-acac-c32413dd1a10" />


#### reference
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#input

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
