### PR TITLE
fix: allow project creation in directories with only .git folder

### DIFF
--- a/packages/create-react-native-library/src/input.ts
+++ b/packages/create-react-native-library/src/input.ts
@@ -210,8 +210,23 @@ export async function createQuestions({
           return 'Cannot be empty';
         }
 
-        if (fs.pathExistsSync(path.join(process.cwd(), input))) {
-          return 'Directory already exists';
+        const targetPath = path.join(process.cwd(), input);
+
+        if (fs.pathExistsSync(targetPath)) {
+          const stat = fs.statSync(targetPath);
+
+          if (!stat.isDirectory()) {
+            return 'Path exists and is not a directory';
+          }
+
+          const files = fs.readdirSync(targetPath);
+
+          const isEmpty =
+            files.length === 0 || (files.length === 1 && files[0] === '.git');
+
+          if (!isEmpty) {
+            return 'Directory already exists';
+          }
         }
 
         return true;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

#### Problem
Currently, the library validation prevents creating projects in directories that contain any files, including `.git` folders. This creates a frustrating user experience when:

1. Users clone an empty GitHub repository
2. The directory contains only a `.git` folder
3. The validation fails with "Directory already exists" error

This is a common workflow where developers create a GitHub repo first, then clone it locally to set up their React Native library.

<img width="838" alt="image" src="https://github.com/user-attachments/assets/85813b62-6954-4775-9794-c065de446f79" />


#### Solution
- Treat directories as "empty" if they contain no files OR only a `.git` folder
- Allow project creation in such directories

This follows the same pattern used by Vite's `create-vite` tool:
- [Vite source code](https://github.com/vitejs/vite/blob/b135918b91e8381c50bd2d076d40e9a65fe68bfe/packages/create-vite/src/index.ts#L589)

### Test plan
1. yarn install
2. cd packages/create-react-native-library
3. yarn prepare
4. run `./bin/create-react-native-library`

Tested scenarios:
- [x] Empty directory - works as before
- [x] Directory with only `.git` - now works ✅
- [x] Directory with other files - still blocked as expected
- [x] Non-existent directory - works as before


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
