### PR TITLE
fix: Remove folly flags that make Nitro Views crash with SIGABRT on RN 0.80

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -29,11 +29,6 @@ Pod::Spec.new do |s|
     "cpp/**/*.{hpp,cpp}",
   ]
 
-  s.pod_target_xcconfig = {
-    # C++ compiler flags, mainly for folly.
-    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES"
-  }
-
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
 


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

See https://github.com/facebook/react-native/issues/52366#issuecomment-3077780700
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
