### PR TITLE
fix(nitro): nitro-codegen is now nitrogen

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -49,7 +49,7 @@
 <% } -%>
     "prepare": "bob build",
 <% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
-    "nitrogen": "nitro-codegen",
+    "nitrogen": "nitrogen",
 <% } -%>
     "release": "release-it --only-version"
   },
@@ -92,7 +92,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",
 <% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
-    "nitro-codegen": "^<%- versions.nitro %>",
+    "nitrogen": "^<%- versions.nitro %>",
 <% } -%>
     "prettier": "^3.6.2",
     "react": "19.1.0",


### PR DESCRIPTION
nitro-codegen is deprecated and is now nitrogen https://www.npmjs.com/package/nitrogen

https://x.com/mrousavy/status/1965693340336484753

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
