### PR TITLE
chore: Rename nitro-codegen to nitrogen

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -48,9 +48,6 @@
     "clean": "del-cli lib",
 <% } -%>
     "prepare": "bob build",
-<% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
-    "nitrogen": "nitro-codegen",
-<% } -%>
     "release": "release-it --only-version"
   },
   "keywords": [
@@ -92,7 +89,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",
 <% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
-    "nitro-codegen": "^<%- versions.nitro %>",
+    "nitrogen": "^<%- versions.nitro %>",
 <% } -%>
     "prettier": "^3.6.2",
     "react": "19.1.0",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Nitro-codegen is renamed to nitrogen .
This fixes below issue
<img width="700" height="160" alt="image" src="https://github.com/user-attachments/assets/b261119d-fa11-4d87-bbad-1895cd07013b" />

 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In the template package.json, switch devDependency from `nitro-codegen` to `nitrogen` and remove the `nitrogen` script.
> 
> - **Templates**:
>   - **`packages/create-react-native-library/templates/common/$package.json`**:
>     - Dev dependency: replace `nitro-codegen` with `nitrogen` when `nitro-modules`/`nitro-view` is selected.
>     - Scripts: remove `"nitrogen": "nitro-codegen"` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c96b49f9dfb1d6934503edda5400f2bd2ed8b8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->