### PR TITLE
fix: nitrogen script  missing during release-it

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -18,7 +18,7 @@
     "android",
     "ios",
     "cpp",
-<% if (project.moduleConfig === "nitro-modules") { -%>
+<% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
     "nitrogen",
     "nitro.json",
 <% } -%>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

I did a mistake here https://github.com/callstack/react-native-builder-bob/pull/891. I shouldn't have removed `"nitrogen":"nitrogen" `. 
During Release `npm run nitrogen` is called i think.
This is breaking release it in case of nitro modules. 

 This also fixes one more thing  
I noticed during nitro views the nitrogen wont be created in files in package.json (verified with `npm pack --dry-run`).

<img width="307" height="349" alt="Screenshot 2025-10-15 at 1 15 41 PM" src="https://github.com/user-attachments/assets/21cd0ecf-7b4d-4a2a-b666-6b5f0cc97925" />

Nitro modules require nitrogen to be present in packaged.

This would fix below issue

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/82098fd8-05b6-4849-8868-0f657e3c7e23" />



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
N/A
