### PR TITLE
fix: remove react-native-safe-area-context from example app

### DIFF
--- a/packages/create-react-native-library/src/exampleApp/generateExampleApp.ts
+++ b/packages/create-react-native-library/src/exampleApp/generateExampleApp.ts
@@ -197,6 +197,8 @@ export default async function generateExampleApp({
   PACKAGES_TO_REMOVE.forEach((name) => {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete devDependencies[name];
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete dependencies[name];
   });
 
   const PACKAGES_TO_ADD_DEV = {


### PR DESCRIPTION
### Summary

Remove `react-native-safe-area-context` from example app as it is not used and is causing Nitro module android build crash mentioned in #896.

### Test plan

Verify that generated libraries build correctly.
