### PR TITLE
fix: Migrate from `TurboReactPackage` to `BaseReactPackage`

### DIFF
--- a/packages/create-react-native-library/templates/nitro-module/android/src/main/java/com/margelo/nitro/{%- project.package_dir %}/{%- project.name %}Package.kt
+++ b/packages/create-react-native-library/templates/nitro-module/android/src/main/java/com/margelo/nitro/{%- project.package_dir %}/{%- project.name %}Package.kt
@@ -1,11 +1,11 @@
 package com.margelo.nitro.<%- project.package %>
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class <%- project.name -%>Package : TurboReactPackage() {
+class <%- project.name -%>Package : BaseReactPackage() {
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
         return null
     }


### PR DESCRIPTION
TurboReactPackage is deprecated by RN

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

See https://github.com/mrousavy/nitro/pull/994


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
