### PR TITLE
refactor: add swift and cpp to source files by default

### DIFF
--- a/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
+++ b/packages/create-react-native-library/templates/native-common/{%- project.name %}.podspec
@@ -13,16 +13,12 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "<%- repo -%>.git", :tag => "#{s.version}" }
 
-<% if (project.moduleConfig !== "nitro-modules" || project.viewConfig === "nitro-view") { -%>
-<% if (project.swift) { -%>
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
-<% } else { -%>
-  s.source_files = "ios/**/*.{h,m,mm,cpp}"
+<% if (project.moduleConfig !== "nitro-modules" && project.viewConfig !== "nitro-view") { -%>
+  s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
+<% if (!project.swift) { -%>
   s.private_header_files = "ios/**/*.h"
 <% } -%>
-<% } -%>
-
-<% if (project.moduleConfig === "nitro-modules" || project.viewConfig === "nitro-view") { -%>
+<% } else { -%>
   s.source_files = [
     "ios/**/*.{swift}",
     "ios/**/*.{m,mm}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the podspec template to include both Swift and C++ sources by default and revises conditional logic for nitro modules/view.
> 
> - **Podspec template (`templates/native-common/{%- project.name %}.podspec`)**:
>   - **Default (non-nitro)**: Use `s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"`; set `s.private_header_files` when `!project.swift`.
>   - **Nitro modules/view**: Use explicit arrays for `ios` Swift/ObjC and `cpp` sources; keep `React-jsi` and `React-callinvoker` dependencies; load autolinking script.
>   - **Logic change**: Switch condition from `||` to `&&` to decide default vs nitro branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74fa92930c87d172824b0b7a92d3eba8decfba7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->