### PR TITLE
chore(gitignore): remove `nitrogen` folder

### DIFF
--- a/packages/create-react-native-library/templates/common/$.gitignore
+++ b/packages/create-react-native-library/templates/common/$.gitignore
@@ -81,6 +81,3 @@ lib/
 # React Native Codegen
 ios/generated
 android/generated
-
-# React Native Nitro Modules
-nitrogen/


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
As Nitro Modules docs recommend, this folder should be tracked in git to improve DX
(https://nitro.margelo.com/docs/nitrogen#2-generate-native-specs)
<img width="988" height="178" alt="image" src="https://github.com/user-attachments/assets/707aeaae-0493-4921-ad4c-0315eb003274" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `nitrogen/` from the template `.gitignore` so the folder is tracked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862aa8c51d644994367d9b15e3084e813a074844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->