### PR TITLE
fix: find tsc in yarn workspace by ensuring no extra ANSI characters are present in 'yarn bin tsc'

### DIFF
--- a/packages/react-native-builder-bob/src/targets/typescript.ts
+++ b/packages/react-native-builder-bob/src/targets/typescript.ts
@@ -112,6 +112,7 @@ export default async function build({
       if (cli === 'yarn') {
         const result = await spawn('yarn', ['bin', 'tsc'], {
           cwd: root,
+          env: { ...process.env, FORCE_COLOR: '0' },
         });
 
         tsc = result.trim();


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When running yarn (tested on ver. `1.22.19`), `yarn bin tsc` run via Node.js `spawn` outputs extra leading ANSI characters, causing the path to `tsc` to look like the following: `\x1B[2K\x1B[1G/Users/<username>/<path to project>/node_modules/.bin/tsc`. This causes any call to `existsSync` to fail (the ANSI chars are non-printable so not visible below, but printing an object with the string as value shows them encoded), showing a false-positive warning:
```
⚠ [typescript] Failed to locate tsc in the workspace. Falling back to the binary found in PATH at /Users/<username>/<path to project>/node_modules/.bin/tsc. Consider adding typescript to your devDependencies or specifying the tsc option for the typescript target.
```

Setting the env var `FORCE_COLOR` to `0` remediates the problem, which this PR brings.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Run `bob build` in a yarn project, ensure tsc is found successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs `yarn bin tsc` with `FORCE_COLOR=0` to avoid ANSI output and correctly detect the `tsc` path.
> 
> - **TypeScript target (`packages/react-native-builder-bob/src/targets/typescript.ts`)**:
>   - For Yarn projects, `spawn('yarn', ['bin', 'tsc'])` now sets `env: { ...process.env, FORCE_COLOR: '0' }` to prevent ANSI characters in output and ensure accurate `tsc` path resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c58e715b829ccd866493d8d3a35b7c0822dbd2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->