### PR TITLE
Duplicated react and react-native dependencies

### DIFF
--- a/packages/create-react-native-library/templates/common/$package.json
+++ b/packages/create-react-native-library/templates/common/$package.json
@@ -87,11 +87,9 @@
   },
   "peerDependencies": {
     "react": "*",
-<% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
     "react-native": "*",
+<% if (project.moduleConfig === 'nitro-modules' || project.viewConfig === 'nitro-view') { -%>
     "react-native-nitro-modules": "^<%- versions.nitro %>"
-<% } else { -%>
-    "react-native": "*"
 <% } -%>
   },
 <% if (example !== 'none') { -%>


### PR DESCRIPTION
Problem creating JS library and adding a simple component since its declaring react and react native into devDependecies as issue #912 (https://github.com/callstack/react-native-builder-bob/issues/912)
<img width="377" height="808" alt="image" src="https://github.com/user-attachments/assets/49141645-0b0b-437b-8e59-a5c8fb28a3a4" />

This PR remove/replace react and react-native from dev dependecies by their types once it should be used on peer dependecies only.

### Summary

as issue https://github.com/callstack/react-native-builder-bob/issues/912
while creat-react-native-library -> JSLibrary, sample project breaks while creating any simple component since they use different types of react and react native reference. one for the library and anathoer for the example.

### Test plan

create a JSLibrary template and add a simple component as suggest below:
<img width="445" height="233" alt="image" src="https://github.com/user-attachments/assets/4f124860-b9ca-4498-a906-2325f3d79df2" />
