### PR TITLE
fix: preserve tsconfig jsx emit in babel builds

### DIFF
--- a/packages/react-native-builder-bob/src/__tests__/babel.test.ts
+++ b/packages/react-native-builder-bob/src/__tests__/babel.test.ts
@@ -1,8 +1,19 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { expect, test } from 'vitest';
+import fsExtra from 'fs-extra';
+import { expect, test, vi } from 'vitest';
 import { transformFileAsync } from '@babel/core';
+import buildModule from '../targets/module.ts';
+import type { Report } from '../types.ts';
 import plugin from '../babel.ts';
+
+const report: Report = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+};
 
 test.each(['imports', 'exports'])(`adds extension to %s`, async (name) => {
   const filepath = path.resolve(
@@ -36,3 +47,53 @@ test.each(['imports', 'exports'])(`adds extension to %s`, async (name) => {
 
   expect(result?.code).toEqual(expected.trim());
 });
+
+test.each(['preserve', 'react-native'])(
+  'preserves JSX when tsconfig compilerOptions.jsx is %s',
+  async (jsx) => {
+    const root = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'bob-babel-'));
+
+    try {
+      await fsExtra.writeJSON(path.join(root, 'package.json'), {
+        name: 'library',
+        version: '1.0.0',
+      });
+
+      await fsExtra.writeJSON(path.join(root, 'tsconfig.json'), {
+        compilerOptions: {
+          jsx,
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          target: 'ESNext',
+        },
+        include: ['src/**/*'],
+      });
+
+      await fsExtra.outputFile(
+        path.join(root, 'src/index.tsx'),
+        'export const Example = () => <View testID="ok" />;\n'
+      );
+
+      await buildModule({
+        root,
+        source: path.join(root, 'src'),
+        output: path.join(root, 'lib/module'),
+        exclude: '',
+        options: {},
+        variants: { module: true },
+        report,
+      });
+
+      const output = await fs.promises.readFile(
+        path.join(root, 'lib/module/index.js'),
+        'utf8'
+      );
+
+      expect(output).toContain('<View testID="ok" />');
+      expect(output).not.toContain('react/jsx-runtime');
+      expect(output).not.toContain('_jsx');
+    } finally {
+      await fsExtra.remove(root);
+    }
+  }
+);

--- a/packages/react-native-builder-bob/src/configs/babel-preset.cjs
+++ b/packages/react-native-builder-bob/src/configs/babel-preset.cjs
@@ -2,12 +2,21 @@
 
 const browserslist = require('browserslist');
 
+const bobPlugin = (() => {
+  try {
+    return require.resolve('../babel');
+  } catch {
+    return require.resolve('../babel.ts');
+  }
+})();
+
 /**
  * Babel preset for React Native Builder Bob
  *
  * @param {Boolean} options.supportsStaticESM - Whether to preserve ESM imports/exports, defaults to `false`
  * @param {Boolean} options.rewriteImportExtensions - Whether to rewrite import extensions to '.js', defaults to `false`
  * @param {'automatic' | 'classic'} options.jsxRuntime - Which JSX runtime to use, defaults to 'automatic'
+ * @param {Boolean} options.preserveJSX - Whether to preserve JSX syntax, defaults to `false`
  */
 module.exports = function (api, options, cwd) {
   const opt = (name) =>
@@ -18,6 +27,7 @@ module.exports = function (api, options, cwd) {
   const supportsStaticESM = opt('supportsStaticESM');
   const rewriteImportExtensions = opt('rewriteImportExtensions');
   const jsxRuntime = opt('jsxRuntime');
+  const preserveJSX = opt('preserveJSX');
 
   return {
     presets: [
@@ -43,12 +53,16 @@ module.exports = function (api, options, cwd) {
           modules: supportsStaticESM ? false : 'commonjs',
         },
       ],
-      [
-        require.resolve('@babel/preset-react'),
-        {
-          runtime: jsxRuntime !== undefined ? jsxRuntime : 'automatic',
-        },
-      ],
+      ...(preserveJSX
+        ? []
+        : [
+            [
+              require.resolve('@babel/preset-react'),
+              {
+                runtime: jsxRuntime !== undefined ? jsxRuntime : 'automatic',
+              },
+            ],
+          ]),
       require.resolve('@babel/preset-typescript'),
     ],
     plugins: [
@@ -59,7 +73,7 @@ module.exports = function (api, options, cwd) {
       ],
       require.resolve('@babel/plugin-transform-flow-strip-types'),
       [
-        require.resolve('../babel'),
+        bobPlugin,
         {
           extension: rewriteImportExtensions ? 'js' : undefined,
         },

--- a/packages/react-native-builder-bob/src/types.ts
+++ b/packages/react-native-builder-bob/src/types.ts
@@ -23,6 +23,7 @@ declare module '@babel/core' {
   export interface TransformCaller {
     rewriteImportExtensions: boolean;
     jsxRuntime: 'automatic' | 'classic';
+    preserveJSX?: boolean;
     codegenEnabled: boolean;
   }
 }

--- a/packages/react-native-builder-bob/src/utils/compile.ts
+++ b/packages/react-native-builder-bob/src/utils/compile.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import kleur from 'kleur';
 import * as babel from '@babel/core';
 import { glob } from 'glob';
+import ts from 'typescript';
 import type { Input, Variants } from '../types.ts';
 import { isCodegenSpec } from './isCodegenSpec.ts';
 
@@ -26,6 +27,29 @@ type Options = Input &
   };
 
 const sourceExt = /\.([cm])?[jt]sx?$/;
+
+const getPreserveJSXFromTsconfig = async (root: string) => {
+  const tsconfig = path.join(root, 'tsconfig.json');
+
+  if (!(await fs.pathExists(tsconfig))) {
+    return false;
+  }
+
+  const configFile = ts.readConfigFile(tsconfig, (file) =>
+    ts.sys.readFile(file)
+  );
+
+  if (configFile.error) {
+    return false;
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, root);
+
+  return (
+    parsed.options.jsx === ts.JsxEmit.Preserve ||
+    parsed.options.jsx === ts.JsxEmit.ReactNative
+  );
+};
 
 export default async function compile({
   root,
@@ -58,6 +82,7 @@ export default async function compile({
   const pkg = JSON.parse(
     await fs.readFile(path.join(root, 'package.json'), 'utf-8')
   );
+  const preserveJSX = await getPreserveJSXFromTsconfig(root);
 
   if (copyFlow) {
     if (!Object.keys(pkg.devDependencies || {}).includes('flow-bin')) {
@@ -131,6 +156,7 @@ export default async function compile({
               : false,
           rewriteImportExtensions: esm,
           jsxRuntime,
+          preserveJSX,
           codegenEnabled,
         },
         cwd: root,


### PR DESCRIPTION
## Summary

Fixes #678.

Preserves JSX during Bob's Babel builds when the project `tsconfig.json` sets `compilerOptions.jsx` to `preserve` or `react-native`.

## Why

Libraries that rely on preserved JSX, for example to use a custom `jsxImportSource`, currently get their TSX output transformed through `@babel/preset-react` anyway. That turns JSX into `react/jsx-runtime` calls even when TypeScript config asks to keep JSX syntax.

## What changed

- Reads `tsconfig.json` with TypeScript's config parser during Babel compilation.
- Passes a `preserveJSX` caller flag to Bob's Babel preset when JSX emit is `preserve` or `react-native`.
- Skips `@babel/preset-react` in that mode so `@babel/preset-typescript` can strip types while leaving JSX intact.
- Adds regression coverage for both `jsx: "preserve"` and `jsx: "react-native"`.

## Test plan

- `YARN_GLOBAL_FOLDER=/tmp/codex-yarn-global-builder-bob yarn workspace react-native-builder-bob test`
- `YARN_GLOBAL_FOLDER=/tmp/codex-yarn-global-builder-bob yarn lint`
- `YARN_GLOBAL_FOLDER=/tmp/codex-yarn-global-builder-bob yarn typecheck`
- `YARN_GLOBAL_FOLDER=/tmp/codex-yarn-global-builder-bob yarn workspace react-native-builder-bob prepare`
- `git diff --check`
